### PR TITLE
Fix: memory leak

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,7 @@
 ---
 BasedOnStyle: LLVM
 Language: Cpp
-Standard: Cpp17
+Standard: c++17
 
 # Indentation
 IndentWidth: 4
@@ -23,9 +23,9 @@ SpacesInParentheses: false
 SpacesInSquareBrackets: false
 
 # Alignment
-AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: false
-AlignOperands: true
+AlignConsecutiveAssignments: None
+AlignConsecutiveDeclarations: None
+AlignOperands: Align
 AlignTrailingComments: true
 
 # Pointers and References
@@ -33,7 +33,7 @@ PointerAlignment: Left
 DerivePointerAlignment: false
 
 # Include sorting
-SortIncludes: true
+SortIncludes: CaseSensitive
 IncludeBlocks: Regroup
 
 # Other

--- a/.clang-format
+++ b/.clang-format
@@ -22,6 +22,9 @@ SpaceInEmptyParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 
+# Breaks
+AlwaysBreakTemplateDeclarations: Yes
+
 # Alignment
 AlignConsecutiveAssignments: None
 AlignConsecutiveDeclarations: None

--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -3,7 +3,7 @@
 # Line width for wrapping
 line_width: 100
 tab_size: 2
-use_tabchars: false  # Use spaces instead of tabs
+use_tabchars: false # Use spaces instead of tabs
 
 # Formatting options
 format:
@@ -21,10 +21,10 @@ format:
 
   # Multi-line formatting for readability
   wrap:
-    long_list: ALWAYS     # Wrap long argument lists (e.g., target_link_libraries)
-    call: MULTILINE       # Wrap multi-line calls consistently
-  continuation_indent: 4  # Indent continuation lines by 4 spaces
-  separate_ctrl_name_with_space: true  # Add space after commands like if(), foreach()
+    long_list: ALWAYS # Wrap long argument lists (e.g., target_link_libraries)
+    call: MULTILINE # Wrap multi-line calls consistently
+  continuation_indent: 4 # Indent continuation lines by 4 spaces
+  separate_ctrl_name_with_space: true # Add space after commands like if(), foreach()
 
 # Parsing options
 parse:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,16 @@ elseif(CMAKE_CXX_STANDARD LESS 17)
   message(FATAL_ERROR "genogrove requires at least C++17")
 endif()
 
+# Sanitizer support
+option(ENABLE_SANITIZER "Enable sanitizers (address, leak, undefined)" OFF)
+if(ENABLE_SANITIZER)
+  message(STATUS "Sanitizers enabled")
+  set(SANITIZER_FLAGS "-fsanitize=address,undefined -fno-omit-frame-pointer -g")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SANITIZER_FLAGS}")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SANITIZER_FLAGS}")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${SANITIZER_FLAGS}")
+endif()
+
 # create the genogrove library
 FILE(GLOB SOURCES "src/*.cpp")
 add_library(genogrove ${SOURCES})

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ CXX_STANDARD ?= 20
 BUILD_DIR ?= build
 SOURCE_DIR ?= .
 GENERATOR ?= Ninja
+ENABLE_SANITIZER ?= OFF
 
 .PHONY: all build rebuild test clean help
 
@@ -19,6 +20,7 @@ build:  ## Build the project
 		-DCMAKE_CXX_STANDARD=$(CXX_STANDARD) \
 		-DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
 		-DBUILD_TESTING=ON \
+		-DENABLE_SANITIZER=$(ENABLE_SANITIZER) \
 		-S $(SOURCE_DIR)
 	@echo "Building project..."
 	@cmake --build $(BUILD_DIR) --config $(BUILD_TYPE)
@@ -50,3 +52,4 @@ help:  ## Show this help message
 	@echo "  make build                        # Just build"
 	@echo "  make BUILD_TYPE=Release           # Release build"
 	@echo "  make GENERATOR=Ninja        # Use Ninja instead"
+	@echo "  make ENABLE_SANITIZER=ON        # Use Ninja instead"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # genogrove
 
 <!-- [![.github/workflows/ci.yml](https://github.com/genogrove/genogrove/actions/workflows/ci.yml/badge.svg)](https://github.com/genogrove/structure/actions/workflows/ci.yml) -->
+
 [![Downloads](https://img.shields.io/github/downloads/genogrove/structure/total.svg)](https://img.shields.io/github/downloads/genogrove/structure/total.svg)
 [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](http://www.gnu.org/licenses/gpl-3.0)
 ![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/genogrove/genogrove?utm_source=oss&utm_medium=github&utm_campaign=genogrove%2Fgenogrove&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
@@ -9,32 +10,44 @@ This repository contains the genogrove library.
 
 ## 🔧 Build Matrix Status
 
-| Compiler     | C++17 | C++20                                                                                                                                                          |
-|--------------|-------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| GCC 12       | TBD   | ![gcc-12-Release](https://img.shields.io/github/actions/workflow/status/genogrove/structure/ci.yml?branch=main&label=gcc-12-Release&style=flat&event=push)     |
-| GCC 13       | TBD   | ![gcc-13-Release](https://img.shields.io/github/actions/workflow/status/genogrove/structure/ci.yml?branch=main&label=gcc-13-Release&style=flat&event=push)     |
-| GCC 14       | TBD   | ![gcc-14-Release](https://img.shields.io/github/actions/workflow/status/genogrove/structure/ci.yml?branch=main&label=gcc-14-Release&style=flat&event=push)     |
-| Clang 14     | TBD   | ![clang-14-Release](https://img.shields.io/github/actions/workflow/status/genogrove/structure/ci.yml?branch=main&label=clang-14-Release&style=flat&event=push) |
+| Compiler | C++17 | C++20                                                                                                                                                          |
+| -------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GCC 12   | TBD   | ![gcc-12-Release](https://img.shields.io/github/actions/workflow/status/genogrove/structure/ci.yml?branch=main&label=gcc-12-Release&style=flat&event=push)     |
+| GCC 13   | TBD   | ![gcc-13-Release](https://img.shields.io/github/actions/workflow/status/genogrove/structure/ci.yml?branch=main&label=gcc-13-Release&style=flat&event=push)     |
+| GCC 14   | TBD   | ![gcc-14-Release](https://img.shields.io/github/actions/workflow/status/genogrove/structure/ci.yml?branch=main&label=gcc-14-Release&style=flat&event=push)     |
+| Clang 14 | TBD   | ![clang-14-Release](https://img.shields.io/github/actions/workflow/status/genogrove/structure/ci.yml?branch=main&label=clang-14-Release&style=flat&event=push) |
 
 ## 🚀 Quick Start
+
 1. Clonse the repository:
-    ```
-    git clone https://github.com/genogrove/structure.git
-    cd structure
+
    ```
+   git clone https://github.com/genogrove/structure.git
+   cd structure
+   ```
+
 2. Build the project (using cmake):
-    ```
-    cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-    cmake --build build
+
    ```
+   cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+   cmake --build build
+   ```
+
 3. Run tests (optional):
-    ```
+
+   ```
    ctest -C Release
    ```
+
    Note this requires the cmake to be called with `-DBUILD_TESTING=ON`
+
 4. Include in your project:
-    - Add structure/include to your include path.
-    - Link against the built library in your cmake or build system
+   - Add structure/include to your include path.
+   - Link against the built library in your cmake or build system
+
+## Development
+
+1. Run sanitizers (AddressSanitizer and UndefinedBehaviorSanitizer) to catch memory issues and undefined behavior during development. See [SANITIZERS.md](SANITIZERS.md) for details.
 
 ## Documentation
 
@@ -42,5 +55,4 @@ An extensive documentation can be found at [www.genogrove.com](https://www.genog
 
 ## License
 
-Distributed under [GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html) 
-
+Distributed under [GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html)

--- a/SANITIZERS.md
+++ b/SANITIZERS.md
@@ -1,0 +1,45 @@
+# Using Sanitizers
+
+This project supports AddressSanitizer and UndefinedBehaviorSanitizer for detecting memory issues and undefined behavior.
+
+## Building with Sanitizers
+
+To enable sanitizers during build:
+
+```bash
+cmake -B build -S . -DENABLE_SANITIZER=ON -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug
+cmake --build
+```
+
+To build without sanitizers (default):
+
+```bash
+cmake -B build -S . -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug
+cmake --build
+```
+
+## Running Tests with Sanitizers
+
+Once built with sanitizers enabled, simply run the tests:
+
+```bash
+./tests/genogrove_structure_tests
+or
+cd build && ctest --output-on-failure
+```
+
+For more detailed leak detection:
+
+```bash
+export ASAN_OPTIONS=detect_leaks=1
+cd build && ./tests/genogrove_structure_tests
+```
+
+## What Sanitizers Detect
+
+- **AddressSanitizer**: Memory leaks, use-after-free, buffer overflows, stack/heap overflow
+- **UndefinedBehaviorSanitizer**: Undefined behavior like null pointer dereference, integer overflow, etc.
+
+## Note
+
+Some false positives may appear from system libraries (e.g., Objective-C runtime on macOS). These can be ignored if they're not from genogrove code.

--- a/include/genogrove/data_type/any_type.hpp
+++ b/include/genogrove/data_type/any_type.hpp
@@ -80,7 +80,8 @@ template <typename T> class any_type : public any_base {
     /*
      * @brief Accesses the contained value for modification.
      * Provides a mutable reference to the stored value so callers can read or modify it in-place.
-     * @return T& Reference to the contained value; remains valid while the object exists and is not moved from or destroyed.
+     * @return T& Reference to the contained value; remains valid while the object exists and is not
+     * moved from or destroyed.
      */
     T& get_data() {
         return data;
@@ -118,7 +119,7 @@ template <typename T> class any_type : public any_base {
         os.write(type_name.c_str(), type_name_len);
 
         os.write(reinterpret_cast<const char*>(&data),
-        sizeof(T)); // write the data
+                 sizeof(T)); // write the data
     }
 
     /*
@@ -136,7 +137,7 @@ template <typename T> class any_type : public any_base {
      * @return std::shared_ptr<any_base> Shared pointer to an any_type<T> holding
      *         the deserialized value.
      */
-    std::shared_ptr<any_base> deserialize(std::istream& is) {
+    std::shared_ptr<any_base> deserialize(std::istream& is) override {
         size_t type_name_len;
         is.read(reinterpret_cast<char*>(&type_name_len), sizeof(type_name_len));
         std::string typeName(type_name_len, '\0');

--- a/include/genogrove/structure/grove/grove.hpp
+++ b/include/genogrove/structure/grove/grove.hpp
@@ -26,7 +26,12 @@ template <typename key_type> class grove {
   public:
     grove(int order) : order(order), root_nodes(), rightmost_nodes() {}
     grove() : order(3), root_nodes(), rightmost_nodes() {}
-    ~grove() {}
+    ~grove() {
+        // Delete all root nodes (which will recursively delete their children)
+        for (auto& [key, root] : root_nodes) {
+            delete root;
+        }
+    }
 
     /*
      * @brief returns the order of the grove

--- a/include/genogrove/structure/grove/grove.hpp
+++ b/include/genogrove/structure/grove/grove.hpp
@@ -14,279 +14,291 @@
 
 // genogrove
 #include "genogrove/utility/ranges.hpp"
-#include <genogrove/data_type/query_result.hpp>
-
 #include "node.hpp"
+
+#include <genogrove/data_type/query_result.hpp>
 
 namespace ggu = genogrove::utility;
 namespace gdt = genogrove::data_type;
 
 namespace genogrove::structure {
-    template<typename key_type>
-    class grove {
-    public:
-        grove(int order) : order(order), root_nodes(), rightmost_nodes() {}
-        grove() : order(3), root_nodes(), rightmost_nodes() {}
-        ~grove() {}
+template <typename key_type> class grove {
+  public:
+    grove(int order) : order(order), root_nodes(), rightmost_nodes() {}
+    grove() : order(3), root_nodes(), rightmost_nodes() {}
+    ~grove() {}
 
-        /*
-         * @brief returns the order of the grove
-         */
-        int get_order() { return this->order; }
+    /*
+     * @brief returns the order of the grove
+     */
+    int get_order() const {
+        return this->order;
+    }
 
-        /*
-         * @brief sets the order of the grove
-         */
-        void set_order(int order) { this->order = order; }
+    /*
+     * @brief sets the order of the grove
+     */
+    void set_order(int order) {
+        this->order = order;
+    }
 
-        /*
-         * @brief return map with root nodes in the grove
-         */
-        std::unordered_map<std::string, node<key_type>*> get_root_nodes() {
-            return this->root_nodes;
+    /*
+     * @brief return map with root nodes in the grove
+     */
+    std::unordered_map<std::string, node<key_type>*> get_root_nodes() const {
+        return this->root_nodes;
+    }
+
+    /*
+     * @brief sets the map with root nodes in the grove
+     */
+    void set_root_nodes(std::unordered_map<std::string, node<key_type>*> root_nodes) {
+        this->root_nodes = root_nodes;
+    }
+
+    /*
+     * @brief returns the rightmost node in the grove (for easy access)
+     * @param The chromosome the grove is associated with
+     */
+    node<key_type>* get_rightmost_node(std::string key) {
+        return this->rightmost_nodes[key];
+    }
+
+    /*
+     * @brief sets the rightmode node in the grove (for easy access)
+     * @param The key the grove is associated with
+     * @param The rightmost node in the grove
+     */
+    void set_rightmost_node(std::string key, node<key_type>* node) {
+        return this->rightmost_nodes[key] = node;
+    }
+
+    /*
+     * @brief get the root node of the grove for a given key
+     * @param The key associated with the root node (of the grove)
+     */
+    node<key_type>* get_root(std::string key) {
+        return ggu::value_lookup(this->root_nodes, key).value_or(nullptr);
+    }
+
+    /*
+     * @brief inserts a new root node into the grove
+     */
+    node<key_type>* insert_root(std::string key) {
+        // check if the root node is already in the map (error)
+        if(ggu::value_lookup(this->root_nodes, key)) {
+            throw std::runtime_error("Root node already exists for key: " + key);
         }
+        node<key_type>* root = new node<key_type>(this->order);
+        this->root_nodes.insert({key, root});
+        root->set_is_leaf(true);
+        this->rightmost_nodes.insert({key, root});
+        return root;
+    }
 
-        /*
-         * @brief sets the map with root nodes in the grove
-         */
-        void set_root_nodes(std::unordered_map<std::string, node<key_type>*> root_nodes) {
-            this->root_nodes = root_nodes;
+    /*
+     * @brief inserts a data point into the grove
+     * @param The key associated with the data point
+     * @param The type of the key to be inserted
+     * @param The data point
+     */
+    template <typename data_type>
+    void insert_data(std::string index, key_type ktype, data_type dtype) {
+        gdt::key<key_type> key(ktype, dtype);
+        insert(index, key);
+    }
+
+    /*
+     * @brief inserts a new key elements into the grove
+     */
+    void insert(std::string index, gdt::key<key_type>& key) {
+        // get the root node for the given chromosome (or create a new one if it doesn't exist)
+        node<key_type>* root = this->get_root(index);
+        if(root == nullptr) {
+            root = this->insert_root(index);
         }
-
-        /*
-         * @brief returns the rightmost node in the grove (for easy access)
-         * @param The chromosome the grove is associated with
-         */
-        node<key_type>* get_rightmost_node(std::string key) {
-            return this->rightmost_nodes[key];
+        insert_iter(root, key);
+        if(root->get_keys().size() == this->order) {
+            node<key_type>* new_root = new node<key_type>(this->order);
+            new_root->add_child(root, 0);
+            new_root->set_is_leaf(false);
+            split_node(new_root, 0);
+            root = new_root;
+            this->root_nodes[index] = root; // update the root node in the map
         }
+    }
 
-        /*
-         * @brief sets the rightmode node in the grove (for easy access)
-         * @param The key the grove is associated with
-         * @param The rightmost node in the grove
-         */
-        void set_rightmost_node(std::string key, node<key_type>* node) {
-            return this->rightmost_nodes[key] = node;
+    /*
+     * @brief inserts a new key into the grove
+     */
+    void insert_iter(node<key_type>* node, gdt::key<key_type>& key) {
+        if(!node) {
+            throw std::runtime_error("Null node passed to insert_iter");
         }
+        if(node->get_is_leaf()) {
+            try {
+                node->insert_key(key);
 
-        /*
-         * @brief get the root node of the grove for a given key
-         * @param The key associated with the root node (of the grove)
-         */
-        node<key_type>* get_root(std::string key) {
-            return ggu::value_lookup(this->root_nodes, key).value_or(nullptr);
-        }
-
-        /*
-         * @brief inserts a new root node into the grove
-         */
-        node<key_type>* insert_root(std::string key) {
-            // check if the root node is already in the map (error)
-            if(ggu::value_lookup(this->root_nodes, key)) {
-                throw std::runtime_error("Root node already exists for key: " + key);
+            } catch(const std::exception& e) {
+                std::cerr << "Failed to insert key into leaf node: " << e.what() << std::endl;
             }
-            node<key_type>* root = new node<key_type>(this->order);
-            this->root_nodes.insert({key, root});
-            root->set_is_leaf(true);
-            this->rightmost_nodes.insert({key, root});
-            return root;
-        }
-
-        /*
-         * @brief inserts a data point into the grove
-         * @param The key associated with the data point
-         * @param The type of the key to be inserted
-         * @param The data point
-         */
-        template<typename data_type>
-        void insert_data(std::string index, key_type ktype, data_type dtype) {
-            gdt::key<key_type> key(ktype, dtype);
-            insert(index, key);
-        }
-
-        /*
-         * @brief inserts a new key elements into the grove
-         */
-        void insert(std::string index, gdt::key<key_type>& key) {
-            // get the root node for the given chromosome (or create a new one if it doesn't exist)
-            node<key_type>* root = this->get_root(index);
-            if(root == nullptr) { root = this->insert_root(index); }
-            insert_iter(root, key);
-            if(root->get_keys().size() == this->order) {
-                node<key_type>* new_root = new node<key_type>(this->order);
-                new_root->add_child(root, 0);
-                new_root->set_is_leaf(false);
-                split_node(new_root, 0);
-                root = new_root;
-                this->root_nodes[index] = root; // update the root node in the map
-            }
-        }
-
-        /*
-         * @brief inserts a new key into the grove
-         */
-        void insert_iter(node<key_type>* node, gdt::key<key_type>& key) {
-            if(!node) { throw std::runtime_error("Null node passed to insert_iter"); }
-            if(node->get_is_leaf()) {
-                try {
-                    node->insert_key(key);
-
-                } catch(const std::exception& e) {
-                    std::cerr << "Failed to insert key into leaf node: " << e.what() << std::endl;
-                }
-            } else {
-                int child_index = 0;
-                while(child_index < node->get_keys().size() &&
-                    key.get_value() > node->get_keys()[child_index].get_value()) {
-                    child_index++;
-                }
-                insert_iter(node->get_child(child_index), key);
-                if(node->get_child(child_index)->get_keys().size() == this->order) {
-                    split_node(node, child_index);
-                }
-            }
-        }
-
-        void split_node(node<key_type>* parent, int index) {
-            node<key_type>* child = parent->get_child(index);
-            node<key_type>* new_child = new node<key_type>(this->order);
-            int mid = ((this->order+2-1)/2);
-
-            // move overflowing keys to the new child node (and resize the original node)
-            new_child->set_is_leaf(child->get_is_leaf());
-
-            new_child->get_keys().assign(child->get_keys().begin() + mid, child->get_keys().end());
-            child->get_keys().resize(mid); // resize the original node
-
-            // update the parent (aka new child node)
-            parent->get_children().insert(parent->get_children().begin() + index + 1, new_child);
-            gdt::key<key_type> parent_key{child->calc_parent_key()};
-            parent->get_keys().insert(parent->get_keys().begin() + index, parent_key);
-
-            if(child->get_is_leaf()) {
-                new_child->set_next(child->get_next());
-                child->set_next(new_child);
-
-                // update the rightmost node if necessary
-                for(auto& [key, rightmost_node] : this->rightmost_nodes) {
-                    if(rightmost_node == child) {
-                        this->rightmost_nodes[key] = new_child;
-                        break;
-                    }
-                }
-            } else {
-                new_child->get_children().assign(child->get_children().begin() + mid, child->get_children().end());
-                child->get_children().resize(mid + 1); // resize the original node
-            }
-        }
-
-        void insert_sorted(gdt::key<key_type>* key, std::string index) {
-            // get the root node for the given index (or create a new one if it doesn't exist)
-            node<key_type>* root = this->get_root(index);
-            if(root == nullptr) {
-                root = insert_root(index);
-                insert_iter(root, index);
-                return;
-            }
-
-            // get the rightmost node and check if the key is sorted (greater than the rightmost key)
-            node<key_type>* rightmost = this->get_rightmost_node(index);
-            if(!rightmost->get_keys().empty() &&
-            key->get_value() <= rightmost->get_keys().back().get_value()) {
-                throw std::runtime_error("Key is not sorted: " + key->get_value());
-            }
-
-            // insert the key into the grove
-            rightmost_nodes->insert_key(key);
-            if(rightmost->get_keys().size() == this->order) {
-                split_node_sorted(rightmost, index);
-            }
-        }
-
-        void split_node_sorted(node<key_type>* node1, const std::string& index) {
-            if(node1 == root_nodes[index]) {
-                node<key_type>* new_root = new node<key_type>(this->order);
-                new_root->add_child(node1, 0);
-                split_node(new_root, 0);
-            }
-
+        } else {
             int child_index = 0;
-            while(child_index < node1->get_parent()->get_children().size()) {
-                if(node1->get_parent()->get_children(child_index) == node1) {
-                    break;
-                }
+            while(child_index < node->get_keys().size() &&
+                  key.get_value() > node->get_keys()[child_index].get_value()) {
                 child_index++;
             }
-            // split the node
-            split_node(node1->get_parent(), child_index);
-            if(node1->get_parent()->get_children().size() == this->order) {
-                split_node_sorted(node1->get_parent(), index);
+            insert_iter(node->get_child(child_index), key);
+            if(node->get_child(child_index)->get_keys().size() == this->order) {
+                split_node(node, child_index);
             }
         }
+    }
 
-        template <typename query_type>
-        gdt::query_result<key_type> intersect(query_type& query) {
-            gdt::query_result<key_type> result{query};
-            // if index is not specified, all root nodes need to be checked
-            for(const auto& [index, root] : this->get_root_nodes()) {
-                search_iter(root, query, result);
+    void split_node(node<key_type>* parent, int index) {
+        node<key_type>* child = parent->get_child(index);
+        node<key_type>* new_child = new node<key_type>(this->order);
+        int mid = ((this->order + 2 - 1) / 2);
+
+        // move overflowing keys to the new child node (and resize the original node)
+        new_child->set_is_leaf(child->get_is_leaf());
+
+        new_child->get_keys().assign(child->get_keys().begin() + mid, child->get_keys().end());
+        child->get_keys().resize(mid); // resize the original node
+
+        // update the parent (aka new child node)
+        parent->get_children().insert(parent->get_children().begin() + index + 1, new_child);
+        gdt::key<key_type> parent_key{child->calc_parent_key()};
+        parent->get_keys().insert(parent->get_keys().begin() + index, parent_key);
+
+        if(child->get_is_leaf()) {
+            new_child->set_next(child->get_next());
+            child->set_next(new_child);
+
+            // update the rightmost node if necessary
+            for(auto& [key, rightmost_node] : this->rightmost_nodes) {
+                if(rightmost_node == child) {
+                    this->rightmost_nodes[key] = new_child;
+                    break;
+                }
             }
-            return result;
+        } else {
+            new_child->get_children().assign(child->get_children().begin() + mid,
+                                             child->get_children().end());
+            child->get_children().resize(mid + 1); // resize the original node
+        }
+    }
+
+    void insert_sorted(gdt::key<key_type>* key, std::string index) {
+        // get the root node for the given index (or create a new one if it doesn't exist)
+        node<key_type>* root = this->get_root(index);
+        if(root == nullptr) {
+            root = insert_root(index);
+            insert_iter(root, index);
+            return;
         }
 
-        // template <typename query_type>
-        gdt::query_result<key_type> intersect(key_type& query, const std::string& index) {
-            gdt::query_result<key_type> result{query};
-            node<key_type>* root = this->get_root(index);
+        // get the rightmost node and check if the key is sorted (greater than the rightmost key)
+        node<key_type>* rightmost = this->get_rightmost_node(index);
+        if(!rightmost->get_keys().empty() &&
+           key->get_value() <= rightmost->get_keys().back().get_value()) {
+            throw std::runtime_error("Key is not sorted: " + key->get_value());
+        }
 
-            if(root == nullptr) { return result; }
+        // insert the key into the grove
+        rightmost_nodes->insert_key(key);
+        if(rightmost->get_keys().size() == this->order) {
+            split_node_sorted(rightmost, index);
+        }
+    }
+
+    void split_node_sorted(node<key_type>* node1, const std::string& index) {
+        if(node1 == root_nodes[index]) {
+            node<key_type>* new_root = new node<key_type>(this->order);
+            new_root->add_child(node1, 0);
+            split_node(new_root, 0);
+        }
+
+        int child_index = 0;
+        while(child_index < node1->get_parent()->get_children().size()) {
+            if(node1->get_parent()->get_children(child_index) == node1) {
+                break;
+            }
+            child_index++;
+        }
+        // split the node
+        split_node(node1->get_parent(), child_index);
+        if(node1->get_parent()->get_children().size() == this->order) {
+            split_node_sorted(node1->get_parent(), index);
+        }
+    }
+
+    template <typename query_type> gdt::query_result<key_type> intersect(query_type& query) {
+        gdt::query_result<key_type> result{query};
+        // if index is not specified, all root nodes need to be checked
+        for(const auto& [index, root] : this->get_root_nodes()) {
             search_iter(root, query, result);
+        }
+        return result;
+    }
+
+    // template <typename query_type>
+    gdt::query_result<key_type> intersect(key_type& query, const std::string& index) {
+        gdt::query_result<key_type> result{query};
+        node<key_type>* root = this->get_root(index);
+
+        if(root == nullptr) {
             return result;
         }
+        search_iter(root, query, result);
+        return result;
+    }
 
-        void search_iter(node<key_type>* node, key_type& query, gdt::query_result<key_type>& result) {
-            if(node == nullptr) { return; }
-            if(node->get_is_leaf()) {
-                int last_match = -1;
-                for(int i = 0; i < node->get_keys().size(); ++i) {
-                    if(key_type::overlap(node->get_keys()[i].get_value(), query)) {
-                        last_match = i;
-                        result.add_key(&node->get_keys()[i]);
-                    }
-                }
-                // check if there is an overlap within the next node (if so we have to traverse it)
-                if (node->get_next() != nullptr) {
-                    int last_key = node->get_keys().size() - 1; // index of the last key in the current node
-                    if (key_type::overlap(node->get_keys()[last_key].get_value(), query)) {
-                        search_iter(node->get_next(), query, result);
-                    }
-                }
-            } else {
-                // abort if left of key (not overlapping) - only neded for intervals
-                if constexpr (key_type::is_interval) {
-                    if (query < node->get_keys()[0].get_value() &&
-                        !key_type::overlap(node->get_keys()[0].get_value(), query)) {
-                        return;
-                    }
-                }
-                int i = 0;
-                while(i < node->get_keys().size() && (query > node->get_keys()[i].get_value())
-                    && !key_type::overlap(node->get_keys()[i].get_value(), query)) { i++; }
-                    if(node->get_children()[i] != nullptr) {
-                        search_iter(node->get_children()[i], query, result);
-                    }
-                }
+    void search_iter(node<key_type>* node, key_type& query, gdt::query_result<key_type>& result) {
+        if(node == nullptr) {
+            return;
         }
+        if(node->get_is_leaf()) {
+            int last_match = -1;
+            for(int i = 0; i < node->get_keys().size(); ++i) {
+                if(key_type::overlap(node->get_keys()[i].get_value(), query)) {
+                    last_match = i;
+                    result.add_key(&node->get_keys()[i]);
+                }
+            }
+            // check if there is an overlap within the next node (if so we have to traverse it)
+            if(node->get_next() != nullptr) {
+                int last_key =
+                    node->get_keys().size() - 1; // index of the last key in the current node
+                if(key_type::overlap(node->get_keys()[last_key].get_value(), query)) {
+                    search_iter(node->get_next(), query, result);
+                }
+            }
+        } else {
+            // abort if left of key (not overlapping) - only neded for intervals
+            if constexpr(key_type::is_interval) {
+                if(query < node->get_keys()[0].get_value() &&
+                   !key_type::overlap(node->get_keys()[0].get_value(), query)) {
+                    return;
+                }
+            }
+            int i = 0;
+            while(i < node->get_keys().size() && (query > node->get_keys()[i].get_value()) &&
+                  !key_type::overlap(node->get_keys()[i].get_value(), query)) {
+                i++;
+            }
+            if(node->get_children()[i] != nullptr) {
+                search_iter(node->get_children()[i], query, result);
+            }
+        }
+    }
 
-    private:
-        int order;
-        std::unordered_map<std::string, node<key_type>*> root_nodes;
-        std::unordered_map<std::string, node<key_type>*> rightmost_nodes;
+  private:
+    int order;
+    std::unordered_map<std::string, node<key_type>*> root_nodes;
+    std::unordered_map<std::string, node<key_type>*> rightmost_nodes;
+};
 
-    };
+} // namespace genogrove::structure
 
-}
-
-
-#endif //STRUCTURE_GROVE_HPP
+#endif // STRUCTURE_GROVE_HPP

--- a/include/genogrove/structure/grove/grove.hpp
+++ b/include/genogrove/structure/grove/grove.hpp
@@ -14,15 +14,15 @@
 
 // genogrove
 #include "genogrove/utility/ranges.hpp"
-#include "node.hpp"
-
 #include <genogrove/data_type/query_result.hpp>
+#include <genogrove/structure/grove/node.hpp>
 
 namespace ggu = genogrove::utility;
 namespace gdt = genogrove::data_type;
 
 namespace genogrove::structure {
-template <typename key_type> class grove {
+template <typename key_type>
+class grove {
   public:
     grove(int order) : order(order), root_nodes(), rightmost_nodes() {}
     grove() : order(3), root_nodes(), rightmost_nodes() {}
@@ -75,7 +75,7 @@ template <typename key_type> class grove {
      * @param The rightmost node in the grove
      */
     void set_rightmost_node(std::string key, node<key_type>* node) {
-        return this->rightmost_nodes[key] = node;
+        this->rightmost_nodes[key] = node;
     }
 
     /*
@@ -199,7 +199,7 @@ template <typename key_type> class grove {
         node<key_type>* root = this->get_root(index);
         if(root == nullptr) {
             root = insert_root(index);
-            insert_iter(root, index);
+            insert_iter(root, key);
             return;
         }
 

--- a/include/genogrove/structure/grove/node.hpp
+++ b/include/genogrove/structure/grove/node.hpp
@@ -19,7 +19,8 @@
 namespace gdt = genogrove::data_type;
 
 namespace genogrove::structure {
-template <typename key_type> class node {
+template <typename key_type>
+class node {
   public:
     node(int order)
         : order(order), keys{}, children{}, parent{nullptr}, next{nullptr}, is_leaf{false} {}

--- a/include/genogrove/structure/grove/node.hpp
+++ b/include/genogrove/structure/grove/node.hpp
@@ -96,6 +96,9 @@ class node {
         this->children.insert(this->children.begin() + index, child);
     }
     node* get_child(int index) {
+        if(index < 0 || index >= this->children.size()) {
+            throw std::out_of_range("child index out of range");
+        }
         return this->children[index];
     }
 

--- a/include/genogrove/structure/grove/node.hpp
+++ b/include/genogrove/structure/grove/node.hpp
@@ -13,107 +13,104 @@
 #include <vector>
 
 // genogrove
-#include "genogrove/data_type/key.hpp"
 #include "genogrove/data_type/interval.hpp"
+#include "genogrove/data_type/key.hpp"
 
 namespace gdt = genogrove::data_type;
 
 namespace genogrove::structure {
-    template <typename key_type>
-    class node {
-        public:
-            node(int order) :
-                order(order),
-                keys{},
-                children{},
-                parent{nullptr},
-                next{nullptr},
-                is_leaf{false} {}
-            ~node();
+template <typename key_type> class node {
+  public:
+    node(int order)
+        : order(order), keys{}, children{}, parent{nullptr}, next{nullptr}, is_leaf{false} {}
+    ~node();
 
-            // getter & setter
-            int get_order() {
-                return this->order;
-            }
-            void set_order(int k) {
-                this->order = k;
-            }
-            std::vector<gdt::key<key_type>>& get_keys() {
-                return this->keys;
-            }
-            void set_keys(std::vector<gdt::key<key_type>> keys) {
-                this->keys = keys;
-            }
-            std::vector<node*>& get_children() {
-                return this->children;
-            }
-            void set_children(std::vector<node*> children) {
-                this->children = children;
-            }
-            node* get_parent() {
-                return this->parent;
-            }
-            void set_parent(node* parent) {
-                this->parent = parent;
-            }
-            void set_next(node* next) {
-                this->next = next;
-            }
-            node* get_next() {
-                return this->next;
-            }
-            void set_is_leaf(bool is_leaf) {
-                this->is_leaf = is_leaf;
-            }
-            bool get_is_leaf() {
-                return this->is_leaf;
-            }
+    // getter & setter
+    int get_order() const {
+        return this->order;
+    }
+    void set_order(int k) {
+        this->order = k;
+    }
+    std::vector<gdt::key<key_type>>& get_keys() {
+        return this->keys;
+    }
+    void set_keys(std::vector<gdt::key<key_type>> keys) {
+        this->keys = keys;
+    }
+    std::vector<node*>& get_children() {
+        return this->children;
+    }
+    void set_children(std::vector<node*> children) {
+        this->children = children;
+    }
+    node* get_parent() const {
+        return this->parent;
+    }
+    void set_parent(node* parent) {
+        this->parent = parent;
+    }
+    void set_next(node* next) {
+        this->next = next;
+    }
+    node* get_next() const {
+        return this->next;
+    }
+    void set_is_leaf(bool is_leaf) {
+        this->is_leaf = is_leaf;
+    }
+    bool get_is_leaf() const {
+        return this->is_leaf;
+    }
 
-            void insert_key(gdt::key<key_type>& key1) {
-                int i = 0;
-                while(i < this->keys.size() && key1.get_value() > this->keys[i].get_value()) { i++; }
-                this->keys.insert(this->keys.begin() + i, key1);
-            }
-            void insert_key(gdt::key<key_type>& key1, int index) {
-                this->keys.insert(this->keys.begin() + index, key1);
-            }
+    void insert_key(gdt::key<key_type>& key1) {
+        int i = 0;
+        while(i < this->keys.size() && key1.get_value() > this->keys[i].get_value()) {
+            i++;
+        }
+        this->keys.insert(this->keys.begin() + i, key1);
+    }
+    void insert_key(gdt::key<key_type>& key1, int index) {
+        this->keys.insert(this->keys.begin() + index, key1);
+    }
 
-            key_type calc_parent_key() {
-                // create vector of reference intervals
-                std::vector<key_type> values = {};
-                for (int i = 0; i < this->keys.size(); i++) {
-                    values.push_back(this->keys[i].get_value());
-                }
-                return key_type::aggregate(values);
-            }
+    key_type calc_parent_key() {
+        // create vector of reference intervals
+        std::vector<key_type> values = {};
+        for(int i = 0; i < this->keys.size(); i++) {
+            values.push_back(this->keys[i].get_value());
+        }
+        return key_type::aggregate(values);
+    }
 
-            void add_child(node* child, int index) {
-                this->children.insert(this->children.begin() + index, child);
-            }
-            node* get_child(int index) { return this->children[index]; }
+    void add_child(node* child, int index) {
+        this->children.insert(this->children.begin() + index, child);
+    }
+    node* get_child(int index) {
+        return this->children[index];
+    }
 
-            /*
-             *
-             */
-            void serialize(std::ostream& os);
-            static node* deserialize(std::istream& is, int order);
+    /*
+     *
+     */
+    void serialize(std::ostream& os);
+    static node* deserialize(std::istream& is, int order);
 
-            void print_keys(std::ostream& os, std::string sep="\t") {
-                for (int i = 0; i < this->keys.size(); ++i) {
-                    os << this->keys[i].get_value().toString() << sep;
-                }
-                os << std::endl;
-            }
+    void print_keys(std::ostream& os, std::string sep = "\t") {
+        for(int i = 0; i < this->keys.size(); ++i) {
+            os << this->keys[i].get_value().toString() << sep;
+        }
+        os << std::endl;
+    }
 
+  private:
+    int order;
+    std::vector<gdt::key<key_type>> keys;
+    std::vector<node*> children;
+    node* parent;
+    node* next;
+    bool is_leaf;
+};
+} // namespace genogrove::structure
 
-        private:
-            int order;
-            std::vector<gdt::key<key_type>> keys;
-            std::vector<node*> children;
-            node* parent;
-            node* next;
-            bool is_leaf;
-    };
-}
-
-#endif //GENOGROVE_STRUCTURE_NODE_HPP
+#endif // GENOGROVE_STRUCTURE_NODE_HPP

--- a/include/genogrove/structure/grove/node.hpp
+++ b/include/genogrove/structure/grove/node.hpp
@@ -23,7 +23,15 @@ template <typename key_type> class node {
   public:
     node(int order)
         : order(order), keys{}, children{}, parent{nullptr}, next{nullptr}, is_leaf{false} {}
-    ~node();
+    ~node() {
+        // Only delete children if this is an internal node
+        // Leaf nodes don't own their children
+        if (!is_leaf) {
+            for (auto* child : children) {
+                delete child;
+            }
+        }
+    }
 
     // getter & setter
     int get_order() const {


### PR DESCRIPTION
# Memory leak for grove tree - reduce memory footprint by 87%


@riasc, We should add a Sanitizer in CI to detect that regularly. Also, we may need to conduct the memory evaluation again. 


## Before: leak 952 bytes (mainly because genogrove)

```
❯ ASAN_OPTIONS=detect_leaks=1 ./tests/genogrove_structure_tests 2>&1                                                                                                                                       Running main() from /Users/ylk4626/ClionProjects/genogrove/build/_deps/googletest-src/googletest/src/gtest_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from interval_grove_test
[ RUN      ] interval_grove_test.interval_creation
number of overlapping intervals: 2
[15,20]
[25,30]
[       OK ] interval_grove_test.interval_creation (1 ms)
[----------] 1 test from interval_grove_test (1 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

=================================================================
==17754==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 80 byte(s) in 1 object(s) allocated from:
    #0 0x000105ac6fe4 in _Znwm+0x6c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x62fe4)
    #1 0x000104cb5b28 in genogrove::structure::grove<genogrove::data_type::interval>::insert(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, genogrove::data_type::key<genogrove::data_type::interval>&) grove.hpp:117
    #2 0x000104cb10dc in void genogrove::structure::grove<genogrove::data_type::interval>::insert_data<int>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, genogrove::data_type::interval, int) grove.hpp:105
    #3 0x000104cb0768 in interval_grove_test_interval_creation_Test::TestBody() interval-grove-test.cpp:37
    #4 0x000104deb7dc in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) gtest.cc:2638
    #5 0x000104d3cd0c in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) gtest.cc:2674
    #6 0x000104d3cab8 in testing::Test::Run() gtest.cc:2713
    #7 0x000104d3ee68 in testing::TestInfo::Run() gtest.cc:2859
    #8 0x000104d41888 in testing::TestSuite::Run() gtest.cc:3037
    #9 0x000104d64c78 in testing::internal::UnitTestImpl::RunAllTests() gtest.cc:5967
    #10 0x000104df8f50 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) gtest.cc:2638
    #11 0x000104d63d90 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) gtest.cc:2674
    #12 0x000104d639b0 in testing::UnitTest::Run() gtest.cc:5546
    #13 0x000104e03e34 in RUN_ALL_TESTS() gtest.h:2334
    #14 0x000104e03d98 in main gtest_main.cc:64
    #15 0x00019e04e0dc  (<unknown module>)
    #16 0x626fffffffffffc  (<unknown module>)

Direct leak of 72 byte(s) in 1 object(s) allocated from:
    #0 0x000105ab74f0 in malloc+0x70 (libclang_rt.asan_osx_dynamic.dylib:arm64+0x534f0)
    #1 0x00019e002e70 in _fetchInitializingClassList(bool)+0x2c (libobjc.A.dylib:arm64+0xae70)
    #2 0xd13600019e002d44  (<unknown module>)
    #3 0x721b00019e002b88  (<unknown module>)
    #4 0x901a00019e002a00  (<unknown module>)
    #5 0x9c7500019e002a00  (<unknown module>)
    #6 0x17380019e002a00  (<unknown module>)
    #7 0xd14e00019e01fbf8  (<unknown module>)
    #8 0x306000019e0025c0  (<unknown module>)
    #9 0x236900019e001f60  (<unknown module>)
    #10 0x721800019e0d8a20  (<unknown module>)
    #11 0x1f7580019e0d7e6c  (<unknown module>)
    #12 0xd1570001ab047648  (<unknown module>)
    #13 0xc96180019e069058  (<unknown module>)
    #14 0xfb2380019e0a7304  (<unknown module>)
    #15 0xf10880019e09a998  (<unknown module>)
    #16 0xc54700019e04a2f8  (<unknown module>)
    #17 0x90b00019e09992c  (<unknown module>)
    #18 0x982b80019e0a6e18  (<unknown module>)
    #19 0x8a6b80019e06506c  (<unknown module>)
    #20 0x7300019e06ed24  (<unknown module>)
    #21 0xe5200019e088358  (<unknown module>)
    #22 0xe51980019e04ef78  (<unknown module>)
    #23 0x330b00019e04ded8  (<unknown module>)
    #24 0x626fffffffffffc  (<unknown module>)

Indirect leak of 256 byte(s) in 1 object(s) allocated from:
    #0 0x000105ac6fe4 in _Znwm+0x6c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x62fe4)
    #1 0x000104cb74e0 in void* std::__1::__libcpp_operator_new[abi:ne200100]<unsigned long>(unsigned long) allocate.h:37
    #2 0x000104cdec98 in genogrove::data_type::key<genogrove::data_type::interval>* std::__1::__libcpp_allocate[abi:ne200100]<genogrove::data_type::key<genogrove::data_type::interval>>(std::__1::__element_count, unsigned long) allocate.h:64
    #3 0x000104cdec30 in std::__1::allocator<genogrove::data_type::key<genogrove::data_type::interval>>::allocate[abi:ne200100](unsigned long) allocator.h:105
    #4 0x000104cdebc8 in std::__1::__allocation_result<std::__1::allocator_traits<std::__1::allocator<genogrove::data_type::key<genogrove::data_type::interval>>>::pointer> std::__1::__allocate_at_least[abi:ne200100]<std::__1::allocator<genogrove::data_type::key<genogrove::data_type::interval>>>(std::__1::allocator<genogrove::data_type::key<genogrove::data_type::interval>>&, unsigned long) allocate_at_least.h:41
    #5 0x000104cdea38 in std::__1::__split_buffer<genogrove::data_type::key<genogrove::data_type::interval>, std::__1::allocator<genogrove::data_type::key<genogrove::data_type::interval>>&>::__split_buffer(unsigned long, unsigned long, std::__1::allocator<genogrove::data_type::key<genogrove::data_type::interval>>&) __split_buffer:325
    #6 0x000104cd870c in std::__1::__split_buffer<genogrove::data_type::key<genogrove::data_type::interval>, std::__1::allocator<genogrove::data_type::key<genogrove::data_type::interval>>&>::__split_buffer(unsigned long, unsigned long, std::__1::allocator<genogrove::data_type::key<genogrove::data_type::interval>>&) __split_buffer:321
    #7 0x000104cd7780 in std::__1::vector<genogrove::data_type::key<genogrove::data_type::interval>, std::__1::allocator<genogrove::data_type::key<genogrove::data_type::interval>>>::insert(std::__1::__wrap_iter<genogrove::data_type::key<genogrove::data_type::interval> const*>, genogrove::data_type::key<genogrove::data_type::interval> const&) vector.h:1196
    #8 0x000104cd71d4 in genogrove::structure::node<genogrove::data_type::interval>::insert_key(genogrove::data_type::key<genogrove::data_type::interval>&) node.hpp:75
    #9 0x000104cd0760 in genogrove::structure::grove<genogrove::data_type::interval>::insert_iter(genogrove::structure::node<genogrove::data_type::interval>*, genogrove::data_type::key<genogrove::data_type::interval>&) grove.hpp:133
    #10 0x000104cb5aac in genogrove::structure::grove<genogrove::data_type::interval>::insert(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, genogrove::data_type::key<genogrove::data_type::interval>&) grove.hpp:115
    #11 0x000104cb10dc in void genogrove::structure::grove<genogrove::data_type::interval>::insert_data<int>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, genogrove::data_type::interval, int) grove.hpp:105
    #12 0x000104cb0768 in interval_grove_test_interval_creation_Test::TestBody() interval-grove-test.cpp:37
    #13 0x000104deb7dc in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) gtest.cc:2638
    #14 0x000104d3cd0c in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) gtest.cc:2674
    #15 0x000104d3cab8 in testing::Test::Run() gtest.cc:2713
    #16 0x000104d3ee68 in testing::TestInfo::Run() gtest.cc:2859
    #17 0x000104d41888 in testing::TestSuite::Run() gtest.cc:3037
    #18 0x000104d64c78 in testing::internal::UnitTestImpl::RunAllTests() gtest.cc:5967
    #19 0x000104df8f50 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) gtest.cc:2638
    #20 0x000104d63d90 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) gtest.cc:2674
    #21 0x000104d639b0 in testing::UnitTest::Run() gtest.cc:5546
    #22 0x000104e03e34 in RUN_ALL_TESTS() gtest.h:2334
    #23 0x000104e03d98 in main gtest_main.cc:64
    #24 0x00019e04e0dc  (<unknown module>)
    #25 0x626fffffffffffc  (<unknown module>)

Indirect leak of 80 byte(s) in 1 object(s) allocated from:
    #0 0x000105ac6fe4 in _Znwm+0x6c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x62fe4)
    #1 0x000104cd11d0 in genogrove::structure::grove<genogrove::data_type::interval>::split_node(genogrove::structure::node<genogrove::data_type::interval>*, int) grove.hpp:153
    #2 0x000104cb5bc8 in genogrove::structure::grove<genogrove::data_type::interval>::insert(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, genogrove::data_type::key<genogrove::data_type::interval>&) grove.hpp:120
    #3 0x000104cb10dc in void genogrove::structure::grove<genogrove::data_type::interval>::insert_data<int>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, genogrove::data_type::interval, int) grove.hpp:105
    #4 0x000104cb0768 in interval_grove_test_interval_creation_Test::TestBody() interval-grove-test.cpp:37
    #5 0x000104deb7dc in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) gtest.cc:2638
    #6 0x000104d3cd0c in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) gtest.cc:2674
    #7 0x000104d3cab8 in testing::Test::Run() gtest.cc:2713
    #8 0x000104d3ee68 in testing::TestInfo::Run() gtest.cc:2859
    #9 0x000104d41888 in testing::TestSuite::Run() gtest.cc:3037
    #10 0x000104d64c78 in testing::internal::UnitTestImpl::RunAllTests() gtest.cc:5967
    #11 0x000104df8f50 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) gtest.cc:2638
    #12 0x000104d63d90 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) gtest.cc:2674
    #13 0x000104d639b0 in testing::UnitTest::Run() gtest.cc:5546
    #14 0x000104e03e34 in RUN_ALL_TESTS() gtest.h:2334
    #15 0x000104e03d98 in main gtest_main.cc:64
    #16 0x00019e04e0dc  (<unknown module>)
    #17 0x626fffffffffffc  (<unknown module>)

Indirect leak of 80 byte(s) in 1 object(s) allocated from:
    #0 0x000105ac6fe4 in _Znwm+0x6c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x62fe4)
    #1 0x000104cd0288 in genogrove::structure::grove<genogrove::data_type::interval>::insert_root(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>) grove.hpp:89
    #2 0x000104cb5a48 in genogrove::structure::grove<genogrove::data_type::interval>::insert(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, genogrove::data_type::key<genogrove::data_type::interval>&) grove.hpp:114
    #3 0x000104cb10dc in void genogrove::structure::grove<genogrove::data_type::interval>::insert_data<int>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, genogrove::data_type::interval, int) grove.hpp:105
    #4 0x000104cb06d8 in interval_grove_test_interval_creation_Test::TestBody() interval-grove-test.cpp:35
    #5 0x000104deb7dc in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) gtest.cc:2638
    #6 0x000104d3cd0c in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) gtest.cc:2674
    #7 0x000104d3cab8 in testing::Test::Run() gtest.cc:2713
    #8 0x000104d3ee68 in testing::TestInfo::Run() gtest.cc:2859
    #9 0x000104d41888 in testing::TestSuite::Run() gtest.cc:3037
    #10 0x000104d64c78 in testing::internal::UnitTestImpl::RunAllTests() gtest.cc:5967
    #11 0x000104df8f50 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) gtest.cc:2638
    #12 0x000104d63d90 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) gtest.cc:2674
    #13 0x000104d639b0 in testing::UnitTest::Run() gtest.cc:5546
    #14 0x000104e03e34 in RUN_ALL_TESTS() gtest.h:2334
    #15 0x000104e03d98 in main gtest_main.cc:64
    #16 0x00019e04e0dc  (<unknown module>)
    #17 0x626fffffffffffc  (<unknown module>)

Indirect leak of 64 byte(s) in 1 object(s) allocated from:
    #0 0x000105ac6fe4 in _Znwm+0x6c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x62fe4)
    #1 0x000104cb74e0 in void* std::__1::__libcpp_operator_new[abi:ne200100]<unsigned long>(unsigned long) allocate.h:37
    #2 0x000104cdec98 in genogrove::data_type::key<genogrove::data_type::interval>* std::__1::__libcpp_allocate[abi:ne200100]<genogrove::data_type::key<genogrove::data_type::interval>>(std::__1::__element_count, unsigned long) allocate.h:64
    #3 0x000104cdec30 in std::__1::allocator<genogrove::data_type::key<genogrove::data_type::interval>>::allocate[abi:ne200100](unsigned long) allocator.h:105
    #4 0x000104cdebc8 in std::__1::__allocation_result<std::__1::allocator_traits<std::__1::allocator<genogrove::data_type::key<genogrove::data_type::interval>>>::pointer> std::__1::__allocate_at_least[abi:ne200100]<std::__1::allocator<genogrove::data_type::key<genogrove::data_type::interval>>>(std::__1::allocator<genogrove::data_type::key<genogrove::data_type::interval>>&, unsigned long) allocate_at_least.h:41
    #5 0x000104ce93b4 in std::__1::vector<genogrove::data_type::key<genogrove::data_type::interval>, std::__1::allocator<genogrove::data_type::key<genogrove::data_type::interval>>>::__vallocate[abi:ne200100](unsigned long) vector.h:562
    #6 0x000104ce8b34 in void std::__1::vector<genogrove::data_type::key<genogrove::data_type::interval>, std::__1::allocator<genogrove::data_type::key<genogrove::data_type::interval>>>::__assign_with_size[abi:ne200100]<std::__1::__wrap_iter<genogrove::data_type::key<genogrove::data_type::interval>*>, std::__1::__wrap_iter<genogrove::data_type::key<genogrove::data_type::interval>*>>(std::__1::__wrap_iter<genogrove::data_type::key<genogrove::data_type::interval>*>, std::__1::__wrap_iter<genogrove::data_type::key<genogrove::data_type::interval>*>, long) vector.h:1060
    #7 0x000104ce7d04 in _ZNSt3__16vectorIN9genogrove9data_type3keyINS2_8intervalEEENS_9allocatorIS5_EEE6assignB8ne200100INS_11__wrap_iterIPS5_EETnNS_9enable_ifIXaasr31__has_forward_iterator_categoryIT_EE5valuesr16is_constructibleIS5_NS_15iterator_traitsISE_E9referenceEEE5valueEiE4typeELi0EEEvSE_SE_ vector.h:317
    #8 0x000104cd132c in genogrove::structure::grove<genogrove::data_type::interval>::split_node(genogrove::structure::node<genogrove::data_type::interval>*, int) grove.hpp:159
    #9 0x000104cb5bc8 in genogrove::structure::grove<genogrove::data_type::interval>::insert(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, genogrove::data_type::key<genogrove::data_type::interval>&) grove.hpp:120
    #10 0x000104cb10dc in void genogrove::structure::grove<genogrove::data_type::interval>::insert_data<int>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, genogrove::data_type::interval, int) grove.hpp:105
    #11 0x000104cb0768 in interval_grove_test_interval_creation_Test::TestBody() interval-grove-test.cpp:37
    #12 0x000104deb7dc in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) gtest.cc:2638
    #13 0x000104d3cd0c in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) gtest.cc:2674
    #14 0x000104d3cab8 in testing::Test::Run() gtest.cc:2713
    #15 0x000104d3ee68 in testing::TestInfo::Run() gtest.cc:2859
    #16 0x000104d41888 in testing::TestSuite::Run() gtest.cc:3037
    #17 0x000104d64c78 in testing::internal::UnitTestImpl::RunAllTests() gtest.cc:5967
    #18 0x000104df8f50 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) gtest.cc:2638
    #19 0x000104d63d90 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) gtest.cc:2674
    #20 0x000104d639b0 in testing::UnitTest::Run() gtest.cc:5546
    #21 0x000104e03e34 in RUN_ALL_TESTS() gtest.h:2334
    #22 0x000104e03d98 in main gtest_main.cc:64
    #23 0x00019e04e0dc  (<unknown module>)
    #24 0x626fffffffffffc  (<unknown module>)

Indirect leak of 64 byte(s) in 1 object(s) allocated from:
    #0 0x000105ac6fe4 in _Znwm+0x6c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x62fe4)
    #1 0x000104cb74e0 in void* std::__1::__libcpp_operator_new[abi:ne200100]<unsigned long>(unsigned long) allocate.h:37
    #2 0x000104cb7460 in std::__1::__shared_ptr_emplace<genogrove::data_type::any_type<int>, std::__1::allocator<genogrove::data_type::any_type<int>>>* std::__1::__libcpp_allocate[abi:ne200100]<std::__1::__shared_ptr_emplace<genogrove::data_type::any_type<int>, std::__1::allocator<genogrove::data_type::any_type<int>>>>(std::__1::__element_count, unsigned long) allocate.h:64
    #3 0x000104cb7398 in std::__1::allocator<std::__1::__shared_ptr_emplace<genogrove::data_type::any_type<int>, std::__1::allocator<genogrove::data_type::any_type<int>>>>::allocate[abi:ne200100](unsigned long) allocator.h:105
    #4 0x000104cb7300 in std::__1::allocator_traits<std::__1::allocator<std::__1::__shared_ptr_emplace<genogrove::data_type::any_type<int>, std::__1::allocator<genogrove::data_type::any_type<int>>>>>::allocate[abi:ne200100](std::__1::allocator<std::__1::__shared_ptr_emplace<genogrove::data_type::any_type<int>, std::__1::allocator<genogrove::data_type::any_type<int>>>>&, unsigned long) allocator_traits.h:270
    #5 0x000104cb71ec in std::__1::__allocation_guard<std::__1::allocator<std::__1::__shared_ptr_emplace<genogrove::data_type::any_type<int>, std::__1::allocator<genogrove::data_type::any_type<int>>>>>::__allocation_guard[abi:ne200100]<std::__1::allocator<genogrove::data_type::any_type<int>>>(std::__1::allocator<genogrove::data_type::any_type<int>>, unsigned long) allocation_guard.h:55
    #6 0x000104cb6d64 in std::__1::__allocation_guard<std::__1::allocator<std::__1::__shared_ptr_emplace<genogrove::data_type::any_type<int>, std::__1::allocator<genogrove::data_type::any_type<int>>>>>::__allocation_guard[abi:ne200100]<std::__1::allocator<genogrove::data_type::any_type<int>>>(std::__1::allocator<genogrove::data_type::any_type<int>>, unsigned long) allocation_guard.h:56
    #7 0x000104cb6b84 in _ZNSt3__115allocate_sharedB8ne200100IN9genogrove9data_type8any_typeIiEENS_9allocatorIS4_EEJRiETnNS_9enable_ifIXntsr8is_arrayIT_EE5valueEiE4typeELi0EEENS_10shared_ptrIS9_EERKT0_DpOT1_ shared_ptr.h:732
    #8 0x000104cb61e0 in _ZNSt3__111make_sharedB8ne200100IN9genogrove9data_type8any_typeIiEEJRiETnNS_9enable_ifIXntsr8is_arrayIT_EE5valueEiE4typeELi0EEENS_10shared_ptrIS7_EEDpOT0_ shared_ptr.h:741
    #9 0x000104cb5f18 in genogrove::data_type::key<genogrove::data_type::interval>::key<int>(genogrove::data_type::interval, int) key.hpp:49
    #10 0x000104cb5894 in genogrove::data_type::key<genogrove::data_type::interval>::key<int>(genogrove::data_type::interval, int) key.hpp:51
    #11 0x000104cb10bc in void genogrove::structure::grove<genogrove::data_type::interval>::insert_data<int>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, genogrove::data_type::interval, int) grove.hpp:104
    #12 0x000104cb0768 in interval_grove_test_interval_creation_Test::TestBody() interval-grove-test.cpp:37
    #13 0x000104deb7dc in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) gtest.cc:2638
    #14 0x000104d3cd0c in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) gtest.cc:2674
    #15 0x000104d3cab8 in testing::Test::Run() gtest.cc:2713
    #16 0x000104d3ee68 in testing::TestInfo::Run() gtest.cc:2859
    #17 0x000104d41888 in testing::TestSuite::Run() gtest.cc:3037
    #18 0x000104d64c78 in testing::internal::UnitTestImpl::RunAllTests() gtest.cc:5967
    #19 0x000104df8f50 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) gtest.cc:2638
    #20 0x000104d63d90 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) gtest.cc:2674
    #21 0x000104d639b0 in testing::UnitTest::Run() gtest.cc:5546
    #22 0x000104e03e34 in RUN_ALL_TESTS() gtest.h:2334
    #23 0x000104e03d98 in main gtest_main.cc:64
    #24 0x00019e04e0dc  (<unknown module>)
    #25 0x626fffffffffffc  (<unknown module>)

Indirect leak of 64 byte(s) in 1 object(s) allocated from:
    #0 0x000105ac6fe4 in _Znwm+0x6c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x62fe4)
    #1 0x000104cb74e0 in void* std::__1::__libcpp_operator_new[abi:ne200100]<unsigned long>(unsigned long) allocate.h:37
    #2 0x000104cb7460 in std::__1::__shared_ptr_emplace<genogrove::data_type::any_type<int>, std::__1::allocator<genogrove::data_type::any_type<int>>>* std::__1::__libcpp_allocate[abi:ne200100]<std::__1::__shared_ptr_emplace<genogrove::data_type::any_type<int>, std::__1::allocator<genogrove::data_type::any_type<int>>>>(std::__1::__element_count, unsigned long) allocate.h:64
    #3 0x000104cb7398 in std::__1::allocator<std::__1::__shared_ptr_emplace<genogrove::data_type::any_type<int>, std::__1::allocator<genogrove::data_type::any_type<int>>>>::allocate[abi:ne200100](unsigned long) allocator.h:105
    #4 0x000104cb7300 in std::__1::allocator_traits<std::__1::allocator<std::__1::__shared_ptr_emplace<genogrove::data_type::any_type<int>, std::__1::allocator<genogrove::data_type::any_type<int>>>>>::allocate[abi:ne200100](std::__1::allocator<std::__1::__shared_ptr_emplace<genogrove::data_type::any_type<int>, std::__1::allocator<genogrove::data_type::any_type<int>>>>&, unsigned long) allocator_traits.h:270
    #5 0x000104cb71ec in std::__1::__allocation_guard<std::__1::allocator<std::__1::__shared_ptr_emplace<genogrove::data_type::any_type<int>, std::__1::allocator<genogrove::data_type::any_type<int>>>>>::__allocation_guard[abi:ne200100]<std::__1::allocator<genogrove::data_type::any_type<int>>>(std::__1::allocator<genogrove::data_type::any_type<int>>, unsigned long) allocation_guard.h:55
    #6 0x000104cb6d64 in std::__1::__allocation_guard<std::__1::allocator<std::__1::__shared_ptr_emplace<genogrove::data_type::any_type<int>, std::__1::allocator<genogrove::data_type::any_type<int>>>>>::__allocation_guard[abi:ne200100]<std::__1::allocator<genogrove::data_type::any_type<int>>>(std::__1::allocator<genogrove::data_type::any_type<int>>, unsigned long) allocation_guard.h:56
    #7 0x000104cb6b84 in _ZNSt3__115allocate_sharedB8ne200100IN9genogrove9data_type8any_typeIiEENS_9allocatorIS4_EEJRiETnNS_9enable_ifIXntsr8is_arrayIT_EE5valueEiE4typeELi0EEENS_10shared_ptrIS9_EERKT0_DpOT1_ shared_ptr.h:732
    #8 0x000104cb61e0 in _ZNSt3__111make_sharedB8ne200100IN9genogrove9data_type8any_typeIiEEJRiETnNS_9enable_ifIXntsr8is_arrayIT_EE5valueEiE4typeELi0EEENS_10shared_ptrIS7_EEDpOT0_ shared_ptr.h:741
    #9 0x000104cb5f18 in genogrove::data_type::key<genogrove::data_type::interval>::key<int>(genogrove::data_type::interval, int) key.hpp:49
    #10 0x000104cb5894 in genogrove::data_type::key<genogrove::data_type::interval>::key<int>(genogrove::data_type::interval, int) key.hpp:51
    #11 0x000104cb10bc in void genogrove::structure::grove<genogrove::data_type::interval>::insert_data<int>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, genogrove::data_type::interval, int) grove.hpp:104
    #12 0x000104cb0720 in interval_grove_test_interval_creation_Test::TestBody() interval-grove-test.cpp:36
    #13 0x000104deb7dc in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) gtest.cc:2638
    #14 0x000104d3cd0c in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) gtest.cc:2674
    #15 0x000104d3cab8 in testing::Test::Run() gtest.cc:2713
    #16 0x000104d3ee68 in testing::TestInfo::Run() gtest.cc:2859
    #17 0x000104d41888 in testing::TestSuite::Run() gtest.cc:3037
    #18 0x000104d64c78 in testing::internal::UnitTestImpl::RunAllTests() gtest.cc:5967
    #19 0x000104df8f50 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) gtest.cc:2638
    #20 0x000104d63d90 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) gtest.cc:2674
    #21 0x000104d639b0 in testing::UnitTest::Run() gtest.cc:5546
    #22 0x000104e03e34 in RUN_ALL_TESTS() gtest.h:2334
    #23 0x000104e03d98 in main gtest_main.cc:64
    #24 0x00019e04e0dc  (<unknown module>)
    #25 0x626fffffffffffc  (<unknown module>)

Indirect leak of 64 byte(s) in 1 object(s) allocated from:
    #0 0x000105ac6fe4 in _Znwm+0x6c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x62fe4)
    #1 0x000104cb74e0 in void* std::__1::__libcpp_operator_new[abi:ne200100]<unsigned long>(unsigned long) allocate.h:37
    #2 0x000104cdec98 in genogrove::data_type::key<genogrove::data_type::interval>* std::__1::__libcpp_allocate[abi:ne200100]<genogrove::data_type::key<genogrove::data_type::interval>>(std::__1::__element_count, unsigned long) allocate.h:64
    #3 0x000104cdec30 in std::__1::allocator<genogrove::data_type::key<genogrove::data_type::interval>>::allocate[abi:ne200100](unsigned long) allocator.h:105
    #4 0x000104cdebc8 in std::__1::__allocation_result<std::__1::allocator_traits<std::__1::allocator<genogrove::data_type::key<genogrove::data_type::interval>>>::pointer> std::__1::__allocate_at_least[abi:ne200100]<std::__1::allocator<genogrove::data_type::key<genogrove::data_type::interval>>>(std::__1::allocator<genogrove::data_type::key<genogrove::data_type::interval>>&, unsigned long) allocate_at_least.h:41
    #5 0x000104cdea38 in std::__1::__split_buffer<genogrove::data_type::key<genogrove::data_type::interval>, std::__1::allocator<genogrove::data_type::key<genogrove::data_type::interval>>&>::__split_buffer(unsigned long, unsigned long, std::__1::allocator<genogrove::data_type::key<genogrove::data_type::interval>>&) __split_buffer:325
    #6 0x000104cd870c in std::__1::__split_buffer<genogrove::data_type::key<genogrove::data_type::interval>, std::__1::allocator<genogrove::data_type::key<genogrove::data_type::interval>>&>::__split_buffer(unsigned long, unsigned long, std::__1::allocator<genogrove::data_type::key<genogrove::data_type::interval>>&) __split_buffer:321
    #7 0x000104cd7780 in std::__1::vector<genogrove::data_type::key<genogrove::data_type::interval>, std::__1::allocator<genogrove::data_type::key<genogrove::data_type::interval>>>::insert(std::__1::__wrap_iter<genogrove::data_type::key<genogrove::data_type::interval> const*>, genogrove::data_type::key<genogrove::data_type::interval> const&) vector.h:1196
    #8 0x000104cd148c in genogrove::structure::grove<genogrove::data_type::interval>::split_node(genogrove::structure::node<genogrove::data_type::interval>*, int) grove.hpp:165
    #9 0x000104cb5bc8 in genogrove::structure::grove<genogrove::data_type::interval>::insert(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, genogrove::data_type::key<genogrove::data_type::interval>&) grove.hpp:120
    #10 0x000104cb10dc in void genogrove::structure::grove<genogrove::data_type::interval>::insert_data<int>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, genogrove::data_type::interval, int) grove.hpp:105
    #11 0x000104cb0768 in interval_grove_test_interval_creation_Test::TestBody() interval-grove-test.cpp:37
    #12 0x000104deb7dc in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) gtest.cc:2638
    #13 0x000104d3cd0c in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) gtest.cc:2674
    #14 0x000104d3cab8 in testing::Test::Run() gtest.cc:2713
    #15 0x000104d3ee68 in testing::TestInfo::Run() gtest.cc:2859
    #16 0x000104d41888 in testing::TestSuite::Run() gtest.cc:3037
    #17 0x000104d64c78 in testing::internal::UnitTestImpl::RunAllTests() gtest.cc:5967
    #18 0x000104df8f50 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) gtest.cc:2638
    #19 0x000104d63d90 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) gtest.cc:2674
    #20 0x000104d639b0 in testing::UnitTest::Run() gtest.cc:5546
    #21 0x000104e03e34 in RUN_ALL_TESTS() gtest.h:2334
    #22 0x000104e03d98 in main gtest_main.cc:64
    #23 0x00019e04e0dc  (<unknown module>)
    #24 0x626fffffffffffc  (<unknown module>)

Indirect leak of 64 byte(s) in 1 object(s) allocated from:
    #0 0x000105ac6fe4 in _Znwm+0x6c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x62fe4)
    #1 0x000104cb74e0 in void* std::__1::__libcpp_operator_new[abi:ne200100]<unsigned long>(unsigned long) allocate.h:37
    #2 0x000104cb7460 in std::__1::__shared_ptr_emplace<genogrove::data_type::any_type<int>, std::__1::allocator<genogrove::data_type::any_type<int>>>* std::__1::__libcpp_allocate[abi:ne200100]<std::__1::__shared_ptr_emplace<genogrove::data_type::any_type<int>, std::__1::allocator<genogrove::data_type::any_type<int>>>>(std::__1::__element_count, unsigned long) allocate.h:64
    #3 0x000104cb7398 in std::__1::allocator<std::__1::__shared_ptr_emplace<genogrove::data_type::any_type<int>, std::__1::allocator<genogrove::data_type::any_type<int>>>>::allocate[abi:ne200100](unsigned long) allocator.h:105
    #4 0x000104cb7300 in std::__1::allocator_traits<std::__1::allocator<std::__1::__shared_ptr_emplace<genogrove::data_type::any_type<int>, std::__1::allocator<genogrove::data_type::any_type<int>>>>>::allocate[abi:ne200100](std::__1::allocator<std::__1::__shared_ptr_emplace<genogrove::data_type::any_type<int>, std::__1::allocator<genogrove::data_type::any_type<int>>>>&, unsigned long) allocator_traits.h:270
    #5 0x000104cb71ec in std::__1::__allocation_guard<std::__1::allocator<std::__1::__shared_ptr_emplace<genogrove::data_type::any_type<int>, std::__1::allocator<genogrove::data_type::any_type<int>>>>>::__allocation_guard[abi:ne200100]<std::__1::allocator<genogrove::data_type::any_type<int>>>(std::__1::allocator<genogrove::data_type::any_type<int>>, unsigned long) allocation_guard.h:55
    #6 0x000104cb6d64 in std::__1::__allocation_guard<std::__1::allocator<std::__1::__shared_ptr_emplace<genogrove::data_type::any_type<int>, std::__1::allocator<genogrove::data_type::any_type<int>>>>>::__allocation_guard[abi:ne200100]<std::__1::allocator<genogrove::data_type::any_type<int>>>(std::__1::allocator<genogrove::data_type::any_type<int>>, unsigned long) allocation_guard.h:56
    #7 0x000104cb6b84 in _ZNSt3__115allocate_sharedB8ne200100IN9genogrove9data_type8any_typeIiEENS_9allocatorIS4_EEJRiETnNS_9enable_ifIXntsr8is_arrayIT_EE5valueEiE4typeELi0EEENS_10shared_ptrIS9_EERKT0_DpOT1_ shared_ptr.h:732
    #8 0x000104cb61e0 in _ZNSt3__111make_sharedB8ne200100IN9genogrove9data_type8any_typeIiEEJRiETnNS_9enable_ifIXntsr8is_arrayIT_EE5valueEiE4typeELi0EEENS_10shared_ptrIS7_EEDpOT0_ shared_ptr.h:741
    #9 0x000104cb5f18 in genogrove::data_type::key<genogrove::data_type::interval>::key<int>(genogrove::data_type::interval, int) key.hpp:49
    #10 0x000104cb5894 in genogrove::data_type::key<genogrove::data_type::interval>::key<int>(genogrove::data_type::interval, int) key.hpp:51
    #11 0x000104cb10bc in void genogrove::structure::grove<genogrove::data_type::interval>::insert_data<int>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, genogrove::data_type::interval, int) grove.hpp:104
    #12 0x000104cb06d8 in interval_grove_test_interval_creation_Test::TestBody() interval-grove-test.cpp:35
    #13 0x000104deb7dc in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) gtest.cc:2638
    #14 0x000104d3cd0c in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) gtest.cc:2674
    #15 0x000104d3cab8 in testing::Test::Run() gtest.cc:2713
    #16 0x000104d3ee68 in testing::TestInfo::Run() gtest.cc:2859
    #17 0x000104d41888 in testing::TestSuite::Run() gtest.cc:3037
    #18 0x000104d64c78 in testing::internal::UnitTestImpl::RunAllTests() gtest.cc:5967
    #19 0x000104df8f50 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) gtest.cc:2638
    #20 0x000104d63d90 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) gtest.cc:2674
    #21 0x000104d639b0 in testing::UnitTest::Run() gtest.cc:5546
    #22 0x000104e03e34 in RUN_ALL_TESTS() gtest.h:2334
    #23 0x000104e03d98 in main gtest_main.cc:64
    #24 0x00019e04e0dc  (<unknown module>)
    #25 0x626fffffffffffc  (<unknown module>)

Indirect leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x000105ab77c8 in calloc+0x78 (libclang_rt.asan_osx_dynamic.dylib:arm64+0x537c8)
    #1 0x00019e002ecc in _fetchInitializingClassList(bool)+0x88 (libobjc.A.dylib:arm64+0xaecc)
    #2 0xd13600019e002d44  (<unknown module>)
    #3 0x721b00019e002b88  (<unknown module>)
    #4 0x901a00019e002a00  (<unknown module>)
    #5 0x9c7500019e002a00  (<unknown module>)
    #6 0x17380019e002a00  (<unknown module>)
    #7 0xd14e00019e01fbf8  (<unknown module>)
    #8 0x306000019e0025c0  (<unknown module>)
    #9 0x236900019e001f60  (<unknown module>)
    #10 0x721800019e0d8a20  (<unknown module>)
    #11 0x1f7580019e0d7e6c  (<unknown module>)
    #12 0xd1570001ab047648  (<unknown module>)
    #13 0xc96180019e069058  (<unknown module>)
    #14 0xfb2380019e0a7304  (<unknown module>)
    #15 0xf10880019e09a998  (<unknown module>)
    #16 0xc54700019e04a2f8  (<unknown module>)
    #17 0x90b00019e09992c  (<unknown module>)
    #18 0x982b80019e0a6e18  (<unknown module>)
    #19 0x8a6b80019e06506c  (<unknown module>)
    #20 0x7300019e06ed24  (<unknown module>)
    #21 0xe5200019e088358  (<unknown module>)
    #22 0xe51980019e04ef78  (<unknown module>)
    #23 0x330b00019e04ded8  (<unknown module>)
    #24 0x626fffffffffffc  (<unknown module>)

Indirect leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x000105ac6fe4 in _Znwm+0x6c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x62fe4)
    #1 0x000104cb74e0 in void* std::__1::__libcpp_operator_new[abi:ne200100]<unsigned long>(unsigned long) allocate.h:37
    #2 0x000104ce5f30 in genogrove::structure::node<genogrove::data_type::interval>** std::__1::__libcpp_allocate[abi:ne200100]<genogrove::structure::node<genogrove::data_type::interval>*>(std::__1::__element_count, unsigned long) allocate.h:64
    #3 0x000104ce5ec8 in std::__1::allocator<genogrove::structure::node<genogrove::data_type::interval>*>::allocate[abi:ne200100](unsigned long) allocator.h:105
    #4 0x000104ce5e60 in std::__1::__allocation_result<std::__1::allocator_traits<std::__1::allocator<genogrove::structure::node<genogrove::data_type::interval>*>>::pointer> std::__1::__allocate_at_least[abi:ne200100]<std::__1::allocator<genogrove::structure::node<genogrove::data_type::interval>*>>(std::__1::allocator<genogrove::structure::node<genogrove::data_type::interval>*>&, unsigned long) allocate_at_least.h:41
    #5 0x000104ce5cd0 in std::__1::__split_buffer<genogrove::structure::node<genogrove::data_type::interval>*, std::__1::allocator<genogrove::structure::node<genogrove::data_type::interval>*>&>::__split_buffer(unsigned long, unsigned long, std::__1::allocator<genogrove::structure::node<genogrove::data_type::interval>*>&) __split_buffer:325
    #6 0x000104ce2fa0 in std::__1::__split_buffer<genogrove::structure::node<genogrove::data_type::interval>*, std::__1::allocator<genogrove::structure::node<genogrove::data_type::interval>*>&>::__split_buffer(unsigned long, unsigned long, std::__1::allocator<genogrove::structure::node<genogrove::data_type::interval>*>&) __split_buffer:321
    #7 0x000104ce2054 in std::__1::vector<genogrove::structure::node<genogrove::data_type::interval>*, std::__1::allocator<genogrove::structure::node<genogrove::data_type::interval>*>>::insert(std::__1::__wrap_iter<genogrove::structure::node<genogrove::data_type::interval>* const*>, genogrove::structure::node<genogrove::data_type::interval>* const&) vector.h:1196
    #8 0x000104cd13d4 in genogrove::structure::grove<genogrove::data_type::interval>::split_node(genogrove::structure::node<genogrove::data_type::interval>*, int) grove.hpp:163
    #9 0x000104cb5bc8 in genogrove::structure::grove<genogrove::data_type::interval>::insert(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, genogrove::data_type::key<genogrove::data_type::interval>&) grove.hpp:120
    #10 0x000104cb10dc in void genogrove::structure::grove<genogrove::data_type::interval>::insert_data<int>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, genogrove::data_type::interval, int) grove.hpp:105
    #11 0x000104cb0768 in interval_grove_test_interval_creation_Test::TestBody() interval-grove-test.cpp:37
    #12 0x000104deb7dc in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) gtest.cc:2638
    #13 0x000104d3cd0c in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) gtest.cc:2674
    #14 0x000104d3cab8 in testing::Test::Run() gtest.cc:2713
    #15 0x000104d3ee68 in testing::TestInfo::Run() gtest.cc:2859
    #16 0x000104d41888 in testing::TestSuite::Run() gtest.cc:3037
    #17 0x000104d64c78 in testing::internal::UnitTestImpl::RunAllTests() gtest.cc:5967
    #18 0x000104df8f50 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) gtest.cc:2638
    #19 0x000104d63d90 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) gtest.cc:2674
    #20 0x000104d639b0 in testing::UnitTest::Run() gtest.cc:5546
    #21 0x000104e03e34 in RUN_ALL_TESTS() gtest.h:2334
    #22 0x000104e03d98 in main gtest_main.cc:64
    #23 0x00019e04e0dc  (<unknown module>)
    #24 0x626fffffffffffc  (<unknown module>)

Indirect leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x000105ab77c8 in calloc+0x78 (libclang_rt.asan_osx_dynamic.dylib:arm64+0x537c8)
    #1 0x00019e002ea8 in _fetchInitializingClassList(bool)+0x64 (libobjc.A.dylib:arm64+0xaea8)
    #2 0xd13600019e002d44  (<unknown module>)
    #3 0x721b00019e002b88  (<unknown module>)
    #4 0x901a00019e002a00  (<unknown module>)
    #5 0x9c7500019e002a00  (<unknown module>)
    #6 0x17380019e002a00  (<unknown module>)
    #7 0xd14e00019e01fbf8  (<unknown module>)
    #8 0x306000019e0025c0  (<unknown module>)
    #9 0x236900019e001f60  (<unknown module>)
    #10 0x721800019e0d8a20  (<unknown module>)
    #11 0x1f7580019e0d7e6c  (<unknown module>)
    #12 0xd1570001ab047648  (<unknown module>)
    #13 0xc96180019e069058  (<unknown module>)
    #14 0xfb2380019e0a7304  (<unknown module>)
    #15 0xf10880019e09a998  (<unknown module>)
    #16 0xc54700019e04a2f8  (<unknown module>)
    #17 0x90b00019e09992c  (<unknown module>)
    #18 0x982b80019e0a6e18  (<unknown module>)
    #19 0x8a6b80019e06506c  (<unknown module>)
    #20 0x7300019e06ed24  (<unknown module>)
    #21 0xe5200019e088358  (<unknown module>)
    #22 0xe51980019e04ef78  (<unknown module>)
    #23 0x330b00019e04ded8  (<unknown module>)
    #24 0x626fffffffffffc  (<unknown module>)

SUMMARY: AddressSanitizer: 952 byte(s) leaked in 13 allocation(s).
```


## After: leak 120 bytes (not related to genogrove)

```
Running main() from /Users/ylk4626/ClionProjects/genogrove/build/_deps/googletest-src/googletest/src/gtest_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from interval_grove_test
[ RUN      ] interval_grove_test.interval_creation
number of overlapping intervals: 2
[15,20]
[25,30]
[       OK ] interval_grove_test.interval_creation (0 ms)
[----------] 1 test from interval_grove_test (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.

=================================================================
==28165==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 72 byte(s) in 1 object(s) allocated from:
    #0 0x0001012bf4f0 in malloc+0x70 (libclang_rt.asan_osx_dynamic.dylib:arm64+0x534f0)
    #1 0x00019e002e70 in _fetchInitializingClassList(bool)+0x2c (libobjc.A.dylib:arm64+0xae70)
    #2 0x604980019e002d44  (<unknown module>)
    #3 0xc85680019e002b88  (<unknown module>)
    #4 0x613080019e002a00  (<unknown module>)
    #5 0x33380019e002a00  (<unknown module>)
    #6 0x3b6a80019e002a00  (<unknown module>)
    #7 0x424e00019e01fbf8  (<unknown module>)
    #8 0x187800019e0025c0  (<unknown module>)
    #9 0x2d4980019e001f60  (<unknown module>)
    #10 0x717b00019e0d8a20  (<unknown module>)
    #11 0x807e80019e0d7e6c  (<unknown module>)
    #12 0x26200001ab047648  (<unknown module>)
    #13 0xde4e00019e069058  (<unknown module>)
    #14 0x336100019e0a7304  (<unknown module>)
    #15 0x307000019e09a998  (<unknown module>)
    #16 0x723080019e04a2f8  (<unknown module>)
    #17 0xa03d80019e09992c  (<unknown module>)
    #18 0x2c6000019e0a6e18  (<unknown module>)
    #19 0x7c2680019e06506c  (<unknown module>)
    #20 0x542200019e06ed24  (<unknown module>)
    #21 0x7c2900019e088358  (<unknown module>)
    #22 0xf02500019e04ef78  (<unknown module>)
    #23 0xe2800019e04ded8  (<unknown module>)
    #24 0x400d7ffffffffffc  (<unknown module>)

Indirect leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x0001012bf7c8 in calloc+0x78 (libclang_rt.asan_osx_dynamic.dylib:arm64+0x537c8)
    #1 0x00019e002ecc in _fetchInitializingClassList(bool)+0x88 (libobjc.A.dylib:arm64+0xaecc)
    #2 0x604980019e002d44  (<unknown module>)
    #3 0xc85680019e002b88  (<unknown module>)
    #4 0x613080019e002a00  (<unknown module>)
    #5 0x33380019e002a00  (<unknown module>)
    #6 0x3b6a80019e002a00  (<unknown module>)
    #7 0x424e00019e01fbf8  (<unknown module>)
    #8 0x187800019e0025c0  (<unknown module>)
    #9 0x2d4980019e001f60  (<unknown module>)
    #10 0x717b00019e0d8a20  (<unknown module>)
    #11 0x807e80019e0d7e6c  (<unknown module>)
    #12 0x26200001ab047648  (<unknown module>)
    #13 0xde4e00019e069058  (<unknown module>)
    #14 0x336100019e0a7304  (<unknown module>)
    #15 0x307000019e09a998  (<unknown module>)
    #16 0x723080019e04a2f8  (<unknown module>)
    #17 0xa03d80019e09992c  (<unknown module>)
    #18 0x2c6000019e0a6e18  (<unknown module>)
    #19 0x7c2680019e06506c  (<unknown module>)
    #20 0x542200019e06ed24  (<unknown module>)
    #21 0x7c2900019e088358  (<unknown module>)
    #22 0xf02500019e04ef78  (<unknown module>)
    #23 0xe2800019e04ded8  (<unknown module>)
    #24 0x400d7ffffffffffc  (<unknown module>)

Indirect leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x0001012bf7c8 in calloc+0x78 (libclang_rt.asan_osx_dynamic.dylib:arm64+0x537c8)
    #1 0x00019e002ea8 in _fetchInitializingClassList(bool)+0x64 (libobjc.A.dylib:arm64+0xaea8)
    #2 0x604980019e002d44  (<unknown module>)
    #3 0xc85680019e002b88  (<unknown module>)
    #4 0x613080019e002a00  (<unknown module>)
    #5 0x33380019e002a00  (<unknown module>)
    #6 0x3b6a80019e002a00  (<unknown module>)
    #7 0x424e00019e01fbf8  (<unknown module>)
    #8 0x187800019e0025c0  (<unknown module>)
    #9 0x2d4980019e001f60  (<unknown module>)
    #10 0x717b00019e0d8a20  (<unknown module>)
    #11 0x807e80019e0d7e6c  (<unknown module>)
    #12 0x26200001ab047648  (<unknown module>)
    #13 0xde4e00019e069058  (<unknown module>)
    #14 0x336100019e0a7304  (<unknown module>)
    #15 0x307000019e09a998  (<unknown module>)
    #16 0x723080019e04a2f8  (<unknown module>)
    #17 0xa03d80019e09992c  (<unknown module>)
    #18 0x2c6000019e0a6e18  (<unknown module>)
    #19 0x7c2680019e06506c  (<unknown module>)
    #20 0x542200019e06ed24  (<unknown module>)
    #21 0x7c2900019e088358  (<unknown module>)
    #22 0xf02500019e04ef78  (<unknown module>)
    #23 0xe2800019e04ded8  (<unknown module>)
    #24 0x400d7ffffffffffc  (<unknown module>)

SUMMARY: AddressSanitizer: 120 byte(s) leaked in 3 allocation(s).

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Data insertion helpers, sorted inserts, query/intersection and iterative search exposed.
  * Optional sanitizer build support (CMake/Makefile) to enable AddressSanitizer/UBSan.

* **Refactor**
  * Const-correctness and public API reorganization for tree structures; improved destructor cleanup and ownership semantics.

* **Style**
  * Updated formatting rules, alignment, include ordering and other formatting tweaks.

* **Documentation**
  * README refinements and new SANITIZERS.md with usage instructions.

* **Other**
  * Minor API consistency/override adjustments for serialization interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->