### PR TITLE
Optimize vector operations with reserve() calls, std::string_view

### DIFF
--- a/include/genogrove/structure/grove/node.hpp
+++ b/include/genogrove/structure/grove/node.hpp
@@ -23,7 +23,11 @@ template <typename key_type>
 class node {
   public:
     node(int order)
-        : order(order), keys{}, children{}, parent{nullptr}, next{nullptr}, is_leaf{false} {}
+        : order(order), keys{}, children{}, parent{nullptr}, next{nullptr}, is_leaf{false} {
+        // Reserve capacity upfront to avoid reallocations
+        keys.reserve(order);
+        children.reserve(order + 1);
+    }
     ~node() {
         // Only delete children if this is an internal node
         // Leaf nodes don't own their children
@@ -84,8 +88,9 @@ class node {
     }
 
     key_type calc_parent_key() {
-        // create vector of reference intervals
-        std::vector<key_type> values = {};
+        // create vector of reference intervals with reserved capacity
+        std::vector<key_type> values;
+        values.reserve(this->keys.size());
         for(int i = 0; i < this->keys.size(); i++) {
             values.push_back(this->keys[i].get_value());
         }

--- a/include/genogrove/structure/grove/node.hpp
+++ b/include/genogrove/structure/grove/node.hpp
@@ -10,6 +10,7 @@
 #define GENOGROVE_STRUCTURE_NODE_HPP
 
 // standard
+#include <string_view>
 #include <vector>
 
 // genogrove
@@ -113,7 +114,7 @@ class node {
     void serialize(std::ostream& os);
     static node* deserialize(std::istream& is, int order);
 
-    void print_keys(std::ostream& os, std::string sep = "\t") {
+    void print_keys(std::ostream& os, std::string_view sep = "\t") {
         for(int i = 0; i < this->keys.size(); ++i) {
             os << this->keys[i].get_value().toString() << sep;
         }


### PR DESCRIPTION
- using std::string_view
- Add reserve() in node constructor for keys and children vectors
- Add reserve() in calc_parent_key() to avoid reallocations
- All tests pass with no performance regression