### PR TITLE
Changes pass-by-const-reference in setters

### DIFF
--- a/include/genogrove/structure/grove/node.hpp
+++ b/include/genogrove/structure/grove/node.hpp
@@ -49,13 +49,13 @@ class node {
     std::vector<gdt::key<key_type>>& get_keys() {
         return this->keys;
     }
-    void set_keys(std::vector<gdt::key<key_type>> keys) {
+    void set_keys(const std::vector<gdt::key<key_type>>& keys) {
         this->keys = keys;
     }
     std::vector<node*>& get_children() {
         return this->children;
     }
-    void set_children(std::vector<node*> children) {
+    void set_children(const std::vector<node*>& children) {
         this->children = children;
     }
     node* get_parent() const {


### PR DESCRIPTION
#Fix 
- setters `set_keys()` and `set_children()` pass now by reference

As with issue #11 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced unnecessary copies when updating tree data, improving efficiency and memory usage, especially on large datasets.

* **Refactor**
  * Updated setter interfaces to accept inputs by reference for safer semantics and better performance.
  * May require minor adjustments in integrations that pass temporaries or rely on implicit copies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->