### PR TITLE
Resolved the typo in SPDX Identifier

### DIFF
--- a/include/genogrove/data_type/any_type.hpp
+++ b/include/genogrove/data_type/any_type.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Indentifier: MIT
+ * SPDX-License-Identifier: MIT
  *
  * Copyright (c) 2025 Richard A. Schäfer
  *

--- a/include/genogrove/data_type/constants.hpp
+++ b/include/genogrove/data_type/constants.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Indentifier: MIT
+ * SPDX-License-Identifier: MIT
  *
  * Copyright (c) 2025 Richard A. Schäfer
  *

--- a/include/genogrove/data_type/genomic_coordinate.hpp
+++ b/include/genogrove/data_type/genomic_coordinate.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Indentifier: MIT
+ * SPDX-License-Identifier: MIT
  *
  * Copyright (c) 2025 Richard A. Schäfer
  *

--- a/include/genogrove/data_type/index.hpp
+++ b/include/genogrove/data_type/index.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Indentifier: MIT
+ * SPDX-License-Identifier: MIT
  *
  * Copyright (c) 2025 Richard A. Schäfer
  *

--- a/include/genogrove/data_type/index_registry.hpp
+++ b/include/genogrove/data_type/index_registry.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Indentifier: MIT
+ * SPDX-License-Identifier: MIT
  *
  * Copyright (c) 2025 Richard A. Schäfer
  *

--- a/include/genogrove/data_type/interval.hpp
+++ b/include/genogrove/data_type/interval.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Indentifier: MIT
+ * SPDX-License-Identifier: MIT
  *
  * Copyright (c) 2025 Richard A. Schäfer
  *

--- a/include/genogrove/data_type/key.hpp
+++ b/include/genogrove/data_type/key.hpp
@@ -1,5 +1,5 @@
 /*
-* SPDX-License-Indentifier: MIT
+ * SPDX-License-Identifier: MIT
  *
  * Copyright (c) 2025 Richard A. Schäfer
  *

--- a/include/genogrove/data_type/key_type_base.hpp
+++ b/include/genogrove/data_type/key_type_base.hpp
@@ -1,3 +1,11 @@
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * Copyright (c) 2025 Richard A. Schäfer
+ *
+ * This file is part of genogrove and is licensed under the terms of the MIT license.
+ * See the LICENSE file in the root of the repository for more information.
+ */
 #ifndef GENOGROVE_DATA_TYPE_KEY_TYPE_BASE_HPP
 #define GENOGROVE_DATA_TYPE_KEY_TYPE_BASE_HPP
 

--- a/include/genogrove/data_type/query_result.hpp
+++ b/include/genogrove/data_type/query_result.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Indentifier: MIT
+ * SPDX-License-Identifier: MIT
  *
  * Copyright (c) 2025 Richard A. Schäfer
  *

--- a/include/genogrove/data_type/type_registry.hpp
+++ b/include/genogrove/data_type/type_registry.hpp
@@ -1,6 +1,5 @@
-
 /*
- * SPDX-License-Indentifier: MIT
+ * SPDX-License-Identifier: MIT
  *
  * Copyright (c) 2025 Richard A. Schäfer
  *

--- a/include/genogrove/structure/grove/grove.hpp
+++ b/include/genogrove/structure/grove/grove.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Indentifier: MIT
+ * SPDX-License-Identifier: MIT
  *
  * Copyright (c) 2025 Richard A. Schäfer
  *

--- a/include/genogrove/structure/grove/node.hpp
+++ b/include/genogrove/structure/grove/node.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Indentifier: MIT
+ * SPDX-License-Identifier: MIT
  *
  * Copyright (c) 2025 Richard A. Schäfer
  *


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Corrected misspelled SPDX license identifiers in multiple headers for consistency and compliance.
  - Added a missing license header to a component.
- Chores
  - No functional, behavioral, or API changes; build and runtime remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->