### PR TITLE
added macos support in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,14 +50,14 @@ jobs:
             c_compiler: clang-14
 
           # exclude gcc/clang on windows
-          - os: windows-2022
-            c_compiler: gcc-12
-          - os: windows-2022
-            c_compiler: gcc-13
-          - os: windows-2022
-            c_compiler: gcc-14
-          - os: windows-2022
-            c_compiler: clang-14
+#          - os: windows-2022
+#            c_compiler: gcc-12
+#          - os: windows-2022
+#            c_compiler: gcc-13
+#          - os: windows-2022
+#            c_compiler: gcc-14
+#          - os: windows-2022
+#            c_compiler: clang-14
 
     steps:
       - name: checkout code


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI matrix expanded to explicitly include macOS (with Windows left as a placeholder); clarified platform-specific steps and limited compiler installation to Linux. Added exclusions for unsupported OS/compiler combinations and consolidated configure/build steps with clearer platform notes.

* **Tests**
  * Broadened cross-platform build validation across additional OSes, compilers, and build types; simplified test invocation to improve failure output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->