### PR TITLE
Benchmark only on main branch (not on PR)

### DIFF
--- a/.github/workflows/continuous-benchmarking.yml
+++ b/.github/workflows/continuous-benchmarking.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 permissions:
   contents: write


### PR DESCRIPTION
https://github.com/benchmark-action/github-action-benchmark?tab=readme-ov-file#caveats

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous benchmarking workflow configuration to run only on pushes to the main branch, removing pull request event triggers. This streamlines CI/CD processes by consolidating benchmark runs to main branch deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->