### PR TITLE
Removed automatic sorting detection in bulk insert to simplicity

### DIFF
--- a/tests/structure/genomic_coordinate-grove-test.cpp
+++ b/tests/structure/genomic_coordinate-grove-test.cpp
@@ -469,7 +469,7 @@ TEST(GenomicCoordinateGroveTest, BulkInsertSorted) {
     };
 
     // Bulk insert sorted data (auto-detects sorted)
-    grove.insert_data("chr1", data, gst::bulk);
+    grove.insert_data("chr1", data, gst::sorted, gst::bulk);
 
     // Query to verify all data was inserted
     gdt::genomic_coordinate query('*', 0, 100);
@@ -554,57 +554,6 @@ TEST(GenomicCoordinateGroveTest, BulkInsertLargeDataset) {
     auto keys = results.get_keys();
     EXPECT_EQ(keys[0]->get_data(), 0);
     EXPECT_EQ(keys[99]->get_data(), 99);
-}
-
-TEST(GenomicCoordinateGroveTest, BulkInsertExplicitUnsorted) {
-    gst::grove<gdt::genomic_coordinate, int> grove(3);
-
-    // Create unsorted data
-    std::vector<std::pair<gdt::genomic_coordinate, int>> data = {
-        {gdt::genomic_coordinate('-', 40, 50), 40},
-        {gdt::genomic_coordinate('+', 5, 10), 10},
-        {gdt::genomic_coordinate('.', 60, 70), 50},
-        {gdt::genomic_coordinate('+', 10, 15), 20},
-        {gdt::genomic_coordinate('-', 20, 30), 30}
-    };
-
-    // Bulk insert with explicit unsorted tag (sorts internally)
-    grove.insert_data("chr1", data, gst::unsorted, gst::bulk);
-
-    // Query to verify all data was inserted
-    gdt::genomic_coordinate query('*', 0, 100);
-    auto results = grove.intersect(query, "chr1");
-
-    ASSERT_EQ(results.get_keys().size(), 5);
-
-    // Verify data was sorted
-    auto keys = results.get_keys();
-    EXPECT_EQ(keys[0]->get_value().get_start(), 5);
-    EXPECT_EQ(keys[0]->get_data(), 10);
-}
-
-TEST(GenomicCoordinateGroveTest, BulkInsertExplicitSorted) {
-    gst::grove<gdt::genomic_coordinate, int> grove(3);
-
-    // Create sorted data
-    std::vector<std::pair<gdt::genomic_coordinate, int>> data = {
-        {gdt::genomic_coordinate('+', 5, 10), 10},
-        {gdt::genomic_coordinate('+', 10, 15), 20},
-        {gdt::genomic_coordinate('-', 20, 30), 30},
-        {gdt::genomic_coordinate('+', 40, 50), 40}
-    };
-
-    // Bulk insert with explicit sorted tag (fastest - no check)
-    grove.insert_data("chr1", data, gst::sorted, gst::bulk);
-
-    // Query to verify
-    gdt::genomic_coordinate query('*', 0, 100);
-    auto results = grove.intersect(query, "chr1");
-
-    ASSERT_EQ(results.get_keys().size(), 4);
-    auto keys = results.get_keys();
-    EXPECT_EQ(keys[0]->get_data(), 10);
-    EXPECT_EQ(keys[3]->get_data(), 40);
 }
 
 TEST(GenomicCoordinateGroveTest, BulkInsertVsIndividualInsert) {
@@ -798,13 +747,13 @@ TEST(GenomicCoordinateGroveTest, BulkInsertAppendWithUnsortedTag) {
     };
     grove.insert_data("chr1", batch1, gst::sorted, gst::bulk);
 
-    // Append unsorted data (should be sorted internally, then appended)
+    // Append unsorted data (sorts internally, then appended)
     std::vector<std::pair<gdt::genomic_coordinate, int>> batch2 = {
         {gdt::genomic_coordinate('+', 70, 80), 4},
         {gdt::genomic_coordinate('.', 50, 60), 3},  // Out of order
         {gdt::genomic_coordinate('-', 90, 100), 5}
     };
-    grove.insert_data("chr1", batch2, gst::unsorted, gst::bulk);
+    grove.insert_data("chr1", batch2, gst::bulk);
 
     // Verify all data is present and correctly sorted
     gdt::genomic_coordinate query('*', 0, 150);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed unsorted insertion mode. The bulk insertion API now requires an explicit sorted flag parameter, changing how batch data is inserted. Direct unsorted insertions are no longer supported.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->