### PR TITLE
refactor vertex count functions

### DIFF
--- a/include/genogrove/structure/grove/graph_overlay.hpp
+++ b/include/genogrove/structure/grove/graph_overlay.hpp
@@ -229,10 +229,10 @@ class graph_overlay {
     }
 
     /*
-     * @brief Get number of keys with outgoing edges
-     * @return Number of source keys
+     * @brief Get number of vertices (keys) with at least one outgoing edge
+     * @return Number of keys that have outgoing edges
      */
-    [[nodiscard]] size_t vertex_count() const {
+    [[nodiscard]] size_t vertex_count_with_edges() const {
         return adjacency.size();
     }
 

--- a/include/genogrove/structure/grove/grove.hpp
+++ b/include/genogrove/structure/grove/grove.hpp
@@ -243,11 +243,21 @@ class grove {
     }
 
     /**
-     * @brief Get number of vertices with outgoing edges (convenience forwarding to graph)
-     * @return Number of keys that have at least one outgoing edge
+     * @brief Get total number of vertices (keys) in the grove
+     * @return Total number of keys in the grove (including isolated vertices with no edges)
+     * @note This counts all keys regardless of whether they have edges
      */
     [[nodiscard]] size_t vertex_count() const {
-        return graph_data.vertex_count();
+        return key_storage.size();
+    }
+
+    /**
+     * @brief Get number of vertices with outgoing edges (convenience forwarding to graph)
+     * @return Number of keys that have at least one outgoing edge
+     * @note This only counts keys that appear as sources in the graph adjacency
+     */
+    [[nodiscard]] size_t vertex_count_with_edges() const {
+        return graph_data.vertex_count_with_edges();
     }
 
     /**

--- a/tests/structure/graph_overlay_test.cpp
+++ b/tests/structure/graph_overlay_test.cpp
@@ -752,9 +752,12 @@ TEST(GraphOverlayTest, MultipleChromosomesComplexGraph) {
     ASSERT_EQ(chr2_e2_chimeric.size(), 1);
     EXPECT_EQ(chr2_e2_chimeric[0], chr3_e1);
 
-    // Verify vertex count (only counts vertices with outgoing edges)
+    // Verify vertex count with edges (only counts vertices with outgoing edges)
     // chr1_e1, chr1_e2, chr2_e1, chr2_e2 have outgoing edges (4 vertices)
     // chr1_e3 and chr3_e1 only have incoming edges, so they're not counted
-    EXPECT_EQ(grove.vertex_count(), 4);
+    EXPECT_EQ(grove.vertex_count_with_edges(), 4);
+
+    // Verify total vertex count (all keys)
+    EXPECT_EQ(grove.vertex_count(), 6);  // All 6 keys inserted
 }
 

--- a/tests/structure/key_type_grove_test.hpp
+++ b/tests/structure/key_type_grove_test.hpp
@@ -555,11 +555,14 @@ protected:
         auto keys = grove.insert_data(get_default_index(), data,
             gst::sorted, gst::bulk);
 
-        // Create chain of edges
+        // Create chain of edges: keys[0] -> keys[1] -> ... -> keys[key_count-1]
+        // This creates key_count-1 edges, with key_count-1 vertices having outgoing edges
+        // (last key has no outgoing edge)
         for (size_t i = 0; i + 1 < keys.size(); ++i) {
             grove.add_edge(keys[i], keys[i + 1]);
         }
-        EXPECT_EQ(grove.vertex_count(), key_count);
+        EXPECT_EQ(grove.vertex_count(), key_count);  // Total vertices (all keys)
+        EXPECT_EQ(grove.vertex_count_with_edges(), key_count - 1);  // Vertices with outgoing edges
         EXPECT_EQ(grove.edge_count(), key_count - 1);
 
         EXPECT_EQ(grove.edge_count(), key_count - 1);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `vertex_count()` method to retrieve the total number of keys in the grove, including isolated ones without edges.
  * Introduced `vertex_count_with_edges()` method to specifically count keys that have outgoing edges.

* **API Changes**
  * Clarified distinction between total key count and edge-connected key count through separate, purpose-specific methods for better code clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->