### PR TITLE
Fix set_root_nodes() deleting new nodes instead of old

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **set_root_nodes() dangling pointer bug**: Fixed `set_root_nodes()` deleting the new parameter's nodes instead of the old member nodes, resulting in dangling pointers ([#93](https://github.com/genogrove/genogrove/issues/93))
+
 ### Changed
 - **grove.hpp cleanup**: Removed dead code (unreachable return, unused try-catch in `insert_iter`), fixed include grouping, removed redundant constructor initializers, fixed typo ([#94](https://github.com/genogrove/genogrove/pull/94))
 

--- a/include/genogrove/structure/grove/grove.hpp
+++ b/include/genogrove/structure/grove/grove.hpp
@@ -455,8 +455,7 @@ class grove {
      * @note This deletes all existing root nodes and clears rightmost node cache
      */
     void set_root_nodes(std::unordered_map<std::string, node<key_type, data_type>*> root_nodes) {
-        // this->root_nodes = root_nodes;
-        for(auto& [_, root] : root_nodes) {
+        for(auto& [_, root] : this->root_nodes) {
             delete root;
         }
         this->root_nodes = std::move(root_nodes);


### PR DESCRIPTION
## Summary
- Fix bug where `set_root_nodes()` deleted the **new** parameter's nodes instead of the **old** member nodes, leaving dangling pointers in the grove

Closes #93

## Root cause
The parameter name `root_nodes` shadowed the member `this->root_nodes`. The delete loop iterated over the parameter (new nodes), then `std::move` transferred the dangling pointers into the member.

## Fix
Changed `for(auto& [_, root] : root_nodes)` to `for(auto& [_, root] : this->root_nodes)` and removed the stale commented-out line.

## Test plan
- [ ] Verify all existing tests pass (`ctest --output-on-failure`)
- [ ] Verify `set_root_nodes()` correctly replaces root nodes without dangling pointers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a memory management issue in the root node replacement operation that could cause dangling pointers by ensuring proper cleanup of existing nodes before assignment.

* **Chores**
  * Code cleanup: removed dead code, reorganized includes, removed redundant initializers, and fixed a typo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->