### PR TITLE
Fix intersect CLI: positional binding and memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **set_root_nodes() dangling pointer bug**: Fixed `set_root_nodes()` deleting the new parameter's nodes instead of the old member nodes, resulting in dangling pointers ([#93](https://github.com/genogrove/genogrove/issues/93))
+- **set_root_nodes() dangling pointer bug**: Fixed `set_root_nodes()` deleting the new parameter's nodes instead of the old member nodes, resulting in dangling pointers ([#93](https://github.com/genogrove/genogrove/issues/93), [#95](https://github.com/genogrove/genogrove/pull/95))
+- **CLI intersect bugs**: Fixed undefined positional binding (`"inputfile"` → `"queryfile", "targetfile"`) and memory leak from raw `new std::ofstream` replaced with `std::unique_ptr` ([#40](https://github.com/genogrove/genogrove/issues/40))
 
 ### Changed
 - **grove.hpp cleanup**: Removed dead code (unreachable return, unused try-catch in `insert_iter`), fixed include grouping, removed redundant constructor initializers, fixed typo ([#94](https://github.com/genogrove/genogrove/pull/94))

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -35,7 +35,7 @@ CPMAddPackage(
 #)
 
 # sources
-file(GLOB CLI_SOURCES src/*.cpp)
+file(GLOB_RECURSE CLI_SOURCES src/*.cpp)
 
 add_executable(genogrove-cli ${CLI_SOURCES})
 target_include_directories(genogrove-cli PUBLIC ${cxxopts_SOURCE_DIR}/include) # include cxxopts headers

--- a/cli/include/handlers/bed.hpp
+++ b/cli/include/handlers/bed.hpp
@@ -31,7 +31,7 @@ void grove_insert(
 
 // Intersect BED query file against a populated grove
 void grove_intersect(
-    const ggs::grove<gdt::interval, gio::bed_entry>& grove,
+    ggs::grove<gdt::interval, gio::bed_entry>& grove,
     const std::string& queryfile,
     std::ostream& output
 );

--- a/cli/include/handlers/gff.hpp
+++ b/cli/include/handlers/gff.hpp
@@ -18,19 +18,20 @@
 
 namespace gdt = genogrove::data_type;
 namespace ggs = genogrove::structure;
+namespace gio = genogrove::io;
 
 namespace handlers {
 namespace gff {
 
 // Insert GFF/GTF file entries into a grove
 void grove_insert(
-    ggs::grove<gdt::interval, gff_entry>& grove,
+    ggs::grove<gdt::interval, gio::gff_entry>& grove,
     const std::string& filepath
 );
 
 // Intersect GFF/GTF query file against a populated grove
 void grove_intersect(
-    const ggs::grove<gdt::interval, gff_entry>& grove,
+    ggs::grove<gdt::interval, gio::gff_entry>& grove,
     const std::string& queryfile,
     std::ostream& output
 );

--- a/cli/include/subcalls/index.hpp
+++ b/cli/include/subcalls/index.hpp
@@ -17,7 +17,6 @@
 // genogrove
 #include <genogrove/data_type/interval.hpp>
 #include <genogrove/structure/grove/grove.hpp>
-#include <genogrove/io/file_reader_factory.hpp>
 
 // genogrove-cli
 #include <subcalls/subcall.hpp>

--- a/cli/include/subcalls/intersect.hpp
+++ b/cli/include/subcalls/intersect.hpp
@@ -15,7 +15,6 @@
 
 // genogrove
 #include <genogrove/structure/all.hpp>
-#include <genogrove/io/file_reader_factory.hpp>
 #include <genogrove/io/filetype_detector.hpp>
 
 // cli

--- a/cli/src/handlers/bed.cpp
+++ b/cli/src/handlers/bed.cpp
@@ -5,10 +5,10 @@ namespace handlers {
 namespace bed {
 
 void grove_insert(
-    ggs::grove<gdt::interval, bed_entry>& grove,
+    ggs::grove<gdt::interval, gio::bed_entry>& grove,
     const std::string& filepath
 ) {
-    bed_reader reader(filepath);
+    gio::bed_reader reader(filepath);
 
     // Use iterator-based approach - no need to initialize entry separately
     for (const auto& entry : reader) {
@@ -18,16 +18,17 @@ void grove_insert(
 }
 
 void grove_intersect(
-    const ggs::grove<gdt::interval, bed_entry>& grove,
+    ggs::grove<gdt::interval, gio::bed_entry>& grove,
     const std::string& queryfile,
     std::ostream& output
 ) {
-    bed_reader reader(queryfile);
+    gio::bed_reader reader(queryfile);
 
     // Use iterator-based approach for cleaner code
     for (const auto& query_entry : reader) {
-        // Intersect query with grove
-        auto results = grove.intersect(query_entry.interval, query_entry.chrom);
+        // Copy interval since intersect() takes non-const reference
+        auto query = query_entry.interval;
+        auto results = grove.intersect(query, query_entry.chrom);
 
         // Output all matching intervals
         for(auto* result : results.get_keys()) {

--- a/cli/src/handlers/gff.cpp
+++ b/cli/src/handlers/gff.cpp
@@ -5,10 +5,10 @@ namespace handlers {
 namespace gff {
 
 void grove_insert(
-    ggs::grove<gdt::interval, gff_entry>& grove,
+    ggs::grove<gdt::interval, gio::gff_entry>& grove,
     const std::string& filepath
 ) {
-    gff_reader reader(filepath);
+    gio::gff_reader reader(filepath);
 
     // Use iterator-based approach - no need to initialize entry separately
     for (const auto& entry : reader) {
@@ -18,16 +18,17 @@ void grove_insert(
 }
 
 void grove_intersect(
-    const ggs::grove<gdt::interval, gff_entry>& grove,
+    ggs::grove<gdt::interval, gio::gff_entry>& grove,
     const std::string& queryfile,
     std::ostream& output
 ) {
-    gff_reader reader(queryfile);
+    gio::gff_reader reader(queryfile);
 
     // Use iterator-based approach for cleaner code
     for (const auto& query_entry : reader) {
-        // Intersect query with grove (using seqid, not chrom!)
-        auto results = grove.intersect(query_entry.interval, query_entry.seqid);
+        // Copy interval since intersect() takes non-const reference
+        auto query = query_entry.interval;
+        auto results = grove.intersect(query, query_entry.seqid);
 
         // Output all matching intervals
         for(auto* result : results.get_keys()) {

--- a/include/genogrove/data_type/any_type.hpp
+++ b/include/genogrove/data_type/any_type.hpp
@@ -12,6 +12,7 @@
 #define GENOGROVE_ANYTYPE_HPP
 
 // Standard
+#include <istream>
 #include <memory>
 #include <ostream>
 #include <string>


### PR DESCRIPTION
## Summary
- Fix undefined positional binding: `parse_positional({"inputfile"})` referenced an undeclared option. Changed to `{"queryfile", "targetfile"}` which are the actual declared options.
- Fix memory leak: raw `new std::ofstream` was never deleted. Replaced with `std::unique_ptr<std::ofstream>` for automatic cleanup.
- Also respect `"stdout"` sentinel in output stream selection to avoid creating an empty file.

Closes #40

## Test plan
- [x] Build CLI with `cmake -B build -S . -DBUILD_CLI=ON` and verify it compiles
- [ ] Run `genogrove_cli isec -q query.bed -t target.bed` and verify argument parsing works
- [ ] Run `genogrove_cli isec query.bed target.bed` (positional) and verify it works
- [ ] Verify output to stdout (default) and to file (`-o output.bed`) both work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed undefined positional argument binding in the intersect command — queryfile and targetfile are now correctly recognized.
  * Resolved a memory leak when writing results to an output file and improved stdout/output redirection handling.
  * Enhanced argument validation to verify file existence and enforce required parameter constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->