### PR TITLE
Fix undefined behavior: ::isdigit on signed char in gff_reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **gff_reader `::isdigit` undefined behavior**: Replaced bare `::isdigit` calls with a safe wrapper that casts to `unsigned char`, matching the pattern already used in `bed_reader` ([#111](https://github.com/genogrove/genogrove/issues/111))
+
+### Changed
+- **CI: split into separate workflows**: Replaced single `ci.yml` with `ci-ubuntu.yml` and `ci-macos.yml` for cleaner matrix configuration. Added Clang 16/17 to Ubuntu and macOS 15 (Apple Clang 16) to macOS. Eliminates all macOS exclude entries ([#105](https://github.com/genogrove/genogrove/pull/105))
+- **README overhaul**: Consolidated badges (single dynamic build badge + static compiler/platform badges), fixed `genogrove/structure` URLs, added usage example, language bindings table, and compiler support section ([#105](https://github.com/genogrove/genogrove/pull/105))
+
 ## [0.15.2] - 2026-02-25
 
 ### Fixed

--- a/src/io/gff_reader.cpp
+++ b/src/io/gff_reader.cpp
@@ -11,6 +11,9 @@
 namespace gdt = genogrove::data_type;
 
 namespace genogrove::io {
+    // Safe isdigit wrapper to avoid UB with signed char
+    static auto is_digit = [](unsigned char c) { return std::isdigit(c) != 0; };
+
     // ==========================================
     // gff_entry helper methods
     // ==========================================
@@ -101,8 +104,8 @@ namespace genogrove::io {
 
             // Validate coordinates are integers
             if (start_str.empty() || end_str.empty() ||
-                !std::all_of(start_str.begin(), start_str.end(), ::isdigit) ||
-                !std::all_of(end_str.begin(), end_str.end(), ::isdigit)) {
+                !std::all_of(start_str.begin(), start_str.end(), is_digit) ||
+                !std::all_of(end_str.begin(), end_str.end(), is_digit)) {
                 if (str.s) free(str.s);
                 bgzf_close(bgzf_file);
                 throw std::runtime_error("Invalid GFF coordinates (non-integer) in " + fpath.string());
@@ -265,8 +268,8 @@ namespace genogrove::io {
 
             // Validate start and end are integers
             if(start_str.empty() || end_str.empty() ||
-               !std::all_of(start_str.begin(), start_str.end(), ::isdigit) ||
-               !std::all_of(end_str.begin(), end_str.end(), ::isdigit)) {
+               !std::all_of(start_str.begin(), start_str.end(), is_digit) ||
+               !std::all_of(end_str.begin(), end_str.end(), is_digit)) {
                 error_message = "Invalid coordinate format at line " + std::to_string(line_num);
                 return false;
             }


### PR DESCRIPTION
## Summary

- Replace bare `::isdigit` calls in `gff_reader.cpp` with a safe `is_digit` lambda wrapper that casts to `unsigned char`, preventing undefined behavior when `char` is signed and input contains values > 127
- Matches the pattern already used in `bed_reader.cpp`

## Test plan

- [x] Existing GFF reader tests pass
- [ ] Verify with `-fsanitize=undefined` that no UB is flagged on GFF files with non-ASCII content

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed undefined behavior in character validation to improve reliability.

* **Changed**
  * Reorganized CI workflows and updated supported compiler versions on Ubuntu and macOS.
  * Enhanced README documentation with usage examples, bindings table, and compiler support information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->