### PR TITLE
Make intersect() accept const key_type& instead of key_type&

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **gff_reader `::isdigit` undefined behavior**: Replaced bare `::isdigit` calls with a safe wrapper that casts to `unsigned char`, matching the pattern already used in `bed_reader` ([#111](https://github.com/genogrove/genogrove/issues/111), [#118](https://github.com/genogrove/genogrove/pull/118))
+- **`intersect()` rejects temporaries**: Changed `intersect()` and `search_iter()` to accept `const key_type&` instead of `key_type&`, allowing idiomatic usage like `grove.intersect(interval{100, 200})` ([#113](https://github.com/genogrove/genogrove/issues/113))
 
 ### Changed
 - **Rename `overlap()` → `is_overlapping()`**: Renamed the static overlap method on all key types (`interval`, `genomic_coordinate`, `numeric`, `kmer`) and in the `key_type_base` concept to `is_overlapping()` for self-documenting intent ([#112](https://github.com/genogrove/genogrove/issues/112), [#119](https://github.com/genogrove/genogrove/pull/119))

--- a/include/genogrove/structure/grove/grove.hpp
+++ b/include/genogrove/structure/grove/grove.hpp
@@ -876,7 +876,7 @@ class grove {
      * @return query_result containing all overlapping keys from all indices
      * @note Searches all root nodes (all chromosomes/indices) in the grove
      */
-    gdt::query_result<key_type, data_type> intersect(key_type& query) {
+    gdt::query_result<key_type, data_type> intersect(const key_type& query) {
         gdt::query_result<key_type, data_type> result{query};
         // if index is not specified, all root nodes need to be checked
         for(const auto& [index, root] : this->get_root_nodes()) {
@@ -892,7 +892,7 @@ class grove {
      * @return query_result containing all overlapping keys from the specified index
      * @note Returns empty result if index doesn't exist
      */
-    gdt::query_result<key_type, data_type> intersect(key_type& query, const std::string& index) {
+    gdt::query_result<key_type, data_type> intersect(const key_type& query, const std::string& index) {
         gdt::query_result<key_type, data_type> result{query};
         node<key_type, data_type>* root = this->get_root(index);
 
@@ -911,7 +911,7 @@ class grove {
      * @note Uses overlap detection to prune search space and traverse linked leaf nodes
      * @note Optimized for interval types with early termination when no overlap is possible
      */
-    void search_iter(node<key_type, data_type>* node, key_type& query,
+    void search_iter(node<key_type, data_type>* node, const key_type& query,
         gdt::query_result<key_type, data_type>& result) {
         if(node == nullptr) {
             return;


### PR DESCRIPTION
## Summary
- Change `intersect()` and `search_iter()` to accept `const key_type&` instead of `key_type&`, allowing temporaries like `grove.intersect(interval{100, 200})`
- The query is never modified, so the non-const reference was needlessly restrictive
- Fully backwards-compatible — existing code with named variables continues to work

Closes #113

## Test plan
- [x] Build with `cmake -DBUILD_TESTING=ON -DBUILD_CLI=ON` — no compile errors
- [x] Run `ctest --output-on-failure` — all existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)