### PR TITLE
Add explicit, const, std::move, fix signed/unsigned

### DIFF
--- a/cli/include/file_entry.hpp
+++ b/cli/include/file_entry.hpp
@@ -25,7 +25,7 @@ struct file_entry {
 
     file_entry() : chrom{""}, interval{0,0}, strand('.') {}
     file_entry(std::string chrom, ggt::interval interval, char strand) :
-        chrom{chrom}, interval{interval}, strand{strand} {}
+        chrom{std::move(chrom)}, interval{interval}, strand{strand} {}
 };
 
 #endif //GENOGROVE_CLI_FILE_ENTRY_HPP

--- a/include/genogrove/data_type/index_registry.hpp
+++ b/include/genogrove/data_type/index_registry.hpp
@@ -41,19 +41,19 @@ namespace genogrove::data_type {
             /*
              * @brief checks if given key has already been registered
              */
-            bool is_registered(const std::string& key);
+            bool is_registered(const std::string& key) const;
 
             /*
              * @brief retrieves the key for a given index (if present)
              * @return std::nullopt if the index is not in the registry
              */
-            std::optional<std::string> key_lookup(uint8_t value);
+            std::optional<std::string> key_lookup(uint8_t value) const;
 
             /*
              * @brief retrieves the index for a given key (if present)
              * @return std::nullopt if the key is not in the registry
              */
-            std::optional<uint8_t> value_lookup(const std::string& key);
+            std::optional<uint8_t> value_lookup(const std::string& key) const;
 
         private:
             std::unordered_map<std::string, uint8_t> registry;

--- a/include/genogrove/data_type/query_result.hpp
+++ b/include/genogrove/data_type/query_result.hpp
@@ -66,7 +66,7 @@ namespace genogrove::data_type {
              *
              * @param query The query used for intersection (stored by value)
              */
-            query_result(key_type query) : query(query), keys{} {}
+            explicit query_result(key_type query) : query(query), keys{} {}
 
             /**
              * @brief Get the original query that produced this result.

--- a/include/genogrove/io/bam_reader.hpp
+++ b/include/genogrove/io/bam_reader.hpp
@@ -356,14 +356,14 @@ namespace genogrove::io {
          *
          * @return Error message string, empty if no error
          */
-        std::string get_error_message() override;
+        std::string get_error_message() const override;
 
         /**
          * @brief Get the current record number (1-based).
          *
          * @return Number of records read so far
          */
-        size_t get_current_line() override;
+        size_t get_current_line() const override;
 
         /**
          * @brief Get the SAM header text.

--- a/include/genogrove/io/bed_reader.hpp
+++ b/include/genogrove/io/bed_reader.hpp
@@ -84,7 +84,7 @@ namespace genogrove::io {
         std::optional<block_info> blocks;
 
         bed_entry() = default;
-        bed_entry(std::string chrom, gdt::interval interval) : chrom(chrom), interval(interval) {}
+        bed_entry(std::string chrom, gdt::interval interval) : chrom(std::move(chrom)), interval(interval) {}
     };
 
     class bed_reader : public file_reader<bed_entry> {
@@ -114,8 +114,8 @@ namespace genogrove::io {
 
         bool read_next(bed_entry& entry) override;
         bool has_next() override;
-        std::string get_error_message() override;
-        size_t get_current_line() override;
+        std::string get_error_message() const override;
+        size_t get_current_line() const override;
         ~bed_reader() override;
 
     private:

--- a/include/genogrove/io/file_reader.hpp
+++ b/include/genogrove/io/file_reader.hpp
@@ -19,8 +19,8 @@ namespace genogrove::io {
     class file_reader_base {
     public:
         virtual bool has_next() = 0;
-        virtual std::string get_error_message() = 0;
-        virtual size_t get_current_line() = 0;
+        virtual std::string get_error_message() const = 0;
+        virtual size_t get_current_line() const = 0;
         virtual ~file_reader_base() = default;
     };
 

--- a/include/genogrove/io/gff_reader.hpp
+++ b/include/genogrove/io/gff_reader.hpp
@@ -47,7 +47,7 @@ namespace genogrove::io {
 
         gff_entry() : format(gff_format::UNKNOWN) {}
         gff_entry(std::string seqid, gdt::interval interval, std::string type)
-            : seqid(seqid), interval(interval), type(type), format(gff_format::UNKNOWN) {}
+            : seqid(std::move(seqid)), interval(interval), type(std::move(type)), format(gff_format::UNKNOWN) {}
 
         // GTF-specific helper methods
         // Returns the value of the gene_id attribute (GTF standard)
@@ -103,8 +103,8 @@ namespace genogrove::io {
 
         bool read_next(gff_entry& entry) override;
         bool has_next() override;
-        std::string get_error_message() override;
-        size_t get_current_line() override;
+        std::string get_error_message() const override;
+        size_t get_current_line() const override;
         ~gff_reader() override;
 
     private:

--- a/include/genogrove/structure/grove/grove.hpp
+++ b/include/genogrove/structure/grove/grove.hpp
@@ -99,7 +99,7 @@ class grove {
      * @brief Construct a grove with specified order
      * @param order Determines the maximum number of k-1 keys and k children per node
      */
-    grove(int order) : order(order) {}
+    explicit grove(int order) : order(order) {}
 
     /**
      * @brief Construct a grove with default order of 3
@@ -781,8 +781,8 @@ class grove {
             // Compute parent separator covering the full left subtree (keys[0..mid])
             // BEFORE modifying the child, so child[mid]'s range is included
             std::vector<key_type> left_subtree_keys;
-            left_subtree_keys.reserve(mid + 1);
-            for (int i = 0; i <= mid; ++i) {
+            left_subtree_keys.reserve(static_cast<size_t>(mid) + 1);
+            for (size_t i = 0; i <= static_cast<size_t>(mid); ++i) {
                 left_subtree_keys.push_back(child->get_keys()[i]->get_value());
             }
             key_type parent_separator = key_type::aggregate(left_subtree_keys);
@@ -917,8 +917,8 @@ class grove {
             return;
         }
         if(node->get_is_leaf()) {
-            int last_match = -1;
-            for(int i = 0; i < node->get_keys().size(); ++i) {
+            std::optional<size_t> last_match;
+            for(size_t i = 0; i < node->get_keys().size(); ++i) {
                 if(key_type::is_overlapping(node->get_keys()[i]->get_value(), query)) {
                     last_match = i;
                     result.add_key(node->get_keys()[i]);
@@ -951,7 +951,7 @@ class grove {
                 }
             }
 
-            int i = 0;
+            size_t i = 0;
             while(i < node->get_keys().size() && (query > node->get_keys()[i]->get_value()) &&
                   !key_type::is_overlapping(node->get_keys()[i]->get_value(), query)) {
                 i++;

--- a/include/genogrove/structure/grove/node.hpp
+++ b/include/genogrove/structure/grove/node.hpp
@@ -59,7 +59,7 @@ class node {
      * - No parent or next sibling (set later during tree operations)
      * - Not marked as leaf (set explicitly when needed)
      */
-    node(int order)
+    explicit node(int order)
         : order(order), keys{}, children{}, parent{nullptr}, next{nullptr}, is_leaf{false} {
         // Reserve capacity upfront to avoid reallocations
         keys.reserve(order-1);
@@ -208,7 +208,7 @@ class node {
      * @note This performs a linear search; consider using indexed insertion for bulk operations
      */
     void insert_key_ptr(gdt::key<key_type, data_type>* key_ptr) {
-        int i = 0;
+        size_t i = 0;
         while(i < this->keys.size() && key_ptr->get_value() > this->keys[i]->get_value()) {
             i++;
         }
@@ -247,7 +247,7 @@ class node {
         // create vector of reference intervals with reserved capacity
         std::vector<key_type> values;
         values.reserve(this->keys.size());
-        for(int i = 0; i < this->keys.size(); i++) {
+        for(size_t i = 0; i < this->keys.size(); i++) {
             values.push_back(this->keys[i]->get_value());
         }
         return key_type::aggregate(values);
@@ -323,7 +323,7 @@ class node {
      * by the specified separator. Useful for debugging and visualization.
      */
     void print_keys(std::ostream& os, std::string_view sep = "\t") {
-        for(int i = 0; i < this->keys.size(); ++i) {
+        for(size_t i = 0; i < this->keys.size(); ++i) {
             os << this->keys[i]->get_value().to_string() << sep;
         }
     }

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -17,15 +17,15 @@ namespace genogrove::data_type {
         return idx.value();
     }
 
-    bool index_registry::is_registered(const std::string &key) {
+    bool index_registry::is_registered(const std::string &key) const {
         return ggu::value_lookup(this->registry, key).has_value();
     }
 
-    std::optional<std::string> index_registry::key_lookup(uint8_t value) {
+    std::optional<std::string> index_registry::key_lookup(uint8_t value) const {
         return ggu::key_lookup(this->registry, value);
     }
 
-    std::optional<uint8_t> index_registry::value_lookup(const std::string &key) {
+    std::optional<uint8_t> index_registry::value_lookup(const std::string &key) const {
         return ggu::value_lookup(this->registry, key);
     }
 }

--- a/src/io/bam_reader.cpp
+++ b/src/io/bam_reader.cpp
@@ -440,11 +440,11 @@ namespace genogrove::io {
         return !at_eof_ && sam_file_ != nullptr;
     }
 
-    std::string bam_reader::get_error_message() {
+    std::string bam_reader::get_error_message() const {
         return error_message_;
     }
 
-    size_t bam_reader::get_current_line() {
+    size_t bam_reader::get_current_line() const {
         return record_num_;
     }
 

--- a/src/io/bed_reader.cpp
+++ b/src/io/bed_reader.cpp
@@ -424,11 +424,11 @@ namespace genogrove::io {
         return peek_result > 0;
     }
 
-    std::string bed_reader::get_error_message() {
+    std::string bed_reader::get_error_message() const {
         return error_message;
     }
 
-    size_t bed_reader::get_current_line() {
+    size_t bed_reader::get_current_line() const {
         return line_num;
     }
 

--- a/src/io/gff_reader.cpp
+++ b/src/io/gff_reader.cpp
@@ -356,11 +356,11 @@ namespace genogrove::io {
         return peek_result > 0;
     }
 
-    std::string gff_reader::get_error_message() {
+    std::string gff_reader::get_error_message() const {
         return error_message;
     }
 
-    size_t gff_reader::get_current_line() {
+    size_t gff_reader::get_current_line() const {
         return line_num;
     }
 


### PR DESCRIPTION
## Summary
- Add `explicit` to single-argument constructors (`node(int)`, `grove(int)`, `query_result(key_type)`) to prevent implicit conversions
- Add `const` to query-only methods on `file_reader_base` and all derived reader classes (`bed_reader`, `gff_reader`, `bam_reader`), plus `index_registry` lookup methods
- Add `std::move` for sink parameters in `bed_entry`, `gff_entry`, and `file_entry` constructors to avoid unnecessary string copies
- Fix signed/unsigned comparison warnings by changing `int` loop variables to `size_t` in `node` and `grove` methods

Closes #115

## Test plan
- [x] Verify project builds without warnings on all CI platforms
- [x] Verify all existing tests pass (no behavioral changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized move semantics for data handling in file operations.
  * Enhanced const-correctness across reader interfaces for improved API clarity.
  * Made constructors explicit to prevent unintended type conversions.

* **Chores**
  * Updated internal type safety in loop operations.
  * Added default constructor option to core data structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->