### PR TITLE
Minor C++20 style cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Refactored
+- **Minor C++20 style cleanups**: Removed redundant `static` from `inline static constexpr` in `grove.hpp`, extraneous semicolon after namespace brace in `any_type.hpp`, unused `start_program` variable in CLI `index.cpp`, and changed `print_general_help()` to take `const cxxopts::Options&` ([#117](https://github.com/genogrove/genogrove/issues/117))
+
 ### Changed
 - **Rename `is_overlapping()` → `overlaps()`** (**breaking**): Renamed the static overlap predicate on all key types (`interval`, `genomic_coordinate`, `numeric`, `kmer`) and in the `key_type_base` concept to `overlaps()` for idiomatic C++ naming. The `is_` prefix is reserved for single-object state checks; `overlaps(a, b)` reads naturally as a two-argument relationship predicate ([#151](https://github.com/genogrove/genogrove/issues/151))
 - **Decouple I/O entry types from `gdt::interval`** (**breaking**): Replaced `gdt::interval interval` field in `bed_entry`, `gff_entry`, and `sam_entry` with plain `size_t start` and `size_t end` fields. Readers now store raw format-native coordinates (0-based half-open) without depending on the grove's key type. Users must construct `gdt::interval(entry.start, entry.end - 1)` when inserting into a grove. CLI handlers updated accordingly ([#153](https://github.com/genogrove/genogrove/issues/153))

--- a/cli/src/index.cpp
+++ b/cli/src/index.cpp
@@ -39,7 +39,6 @@ void index::validate(const cxxopts::ParseResult& args) {
 }
 
 void index::execute(const cxxopts::ParseResult& args) {
-    auto start_program = std::chrono::steady_clock::now();
     std::filesystem::path inputfile = args["inputfile"].as<std::string>();
     std::cout << "Indexing file: " << inputfile << "\n";
 

--- a/cli/src/main.cpp
+++ b/cli/src/main.cpp
@@ -20,7 +20,7 @@ std::unique_ptr<subcalls::subcall> create_subcall(const std::string& subcall) {
     }
 }
 
-void print_general_help(cxxopts::Options& options) {
+void print_general_help(const cxxopts::Options& options) {
     std::cout << options.help() << "\n";
     std::cout << "Available subcommands: \n";
     std::cout << "\tidx:\t\tIndex an Interval File\n";

--- a/include/genogrove/data_type/any_type.hpp
+++ b/include/genogrove/data_type/any_type.hpp
@@ -151,6 +151,6 @@ template <typename T> class any_type : public any_base {
         return std::make_shared<any_type<T>>(data);
     }
 };
-}; // namespace genogrove::data_type
+} // namespace genogrove::data_type
 
 #endif // GENOGROVE_ANYTYPE_HPP

--- a/include/genogrove/structure/grove/grove.hpp
+++ b/include/genogrove/structure/grove/grove.hpp
@@ -41,10 +41,10 @@ namespace genogrove::structure {
     struct bulk_t {};
 
     /// Global constant for sorted insertion dispatch
-    inline static constexpr sorted_t sorted{};
+    inline constexpr sorted_t sorted{};
 
     /// Global constant for bulk insertion dispatch
-    inline static constexpr bulk_t bulk{};
+    inline constexpr bulk_t bulk{};
 
     namespace detail {
         // Type trait to detect if a type is std::optional


### PR DESCRIPTION
## Summary
- Remove redundant `static` from `inline static constexpr` tag dispatch constants in `grove.hpp`
- Remove extraneous semicolon after namespace closing brace in `any_type.hpp`
- Remove unused `start_program` variable (dead code) in CLI `index.cpp`
- Change `print_general_help()` to take `const cxxopts::Options&` in `main.cpp`

## Test plan
- [x] Build with `cmake --build build` (all supported compilers)
- [x] Run `ctest --output-on-failure`
- [x] CI passes

Part of #117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Code quality improvements including removal of unused variable and extraneous syntax elements.

* **Style**
  * Applied C++20 style cleanups and const-correctness enhancements across codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->