### PR TITLE
Minor performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Deleted unused `file_entry.hpp`**: Removed the legacy `file_entry` struct from the CLI, which was never used outside a commented-out reference in `index.cpp` ([#153](https://github.com/genogrove/genogrove/issues/153))
 - **Remove legacy type erasure code**: Deleted `any_type.hpp`, `type_registry.hpp`, and `type_registry.cpp` — unused since the library moved from runtime type erasure to compile-time templates. Cleaned up dead includes from `key.hpp` and `query_result.hpp`
 
+### Performance
+- **Minor performance improvements**: Replaced `std::ostringstream` with `std::format` in `genomic_coordinate::to_string()`, added `reserve()` to `get_neighbors_if()`, simplified BAM tag key construction, and cached redundant `args.as<std::string>()` calls in CLI `intersect.cpp` ([#172](https://github.com/genogrove/genogrove/issues/172))
+
 ## [0.16.0] - 2026-03-01
 
 ### Fixed

--- a/cli/src/intersect.cpp
+++ b/cli/src/intersect.cpp
@@ -28,8 +28,9 @@ void intersect::validate(const cxxopts::ParseResult& args) {
         std::cerr << "Error: queryfile is required\n";
         exit(1);
     }
-    if(!std::filesystem::exists(args["queryfile"].as<std::string>())) {
-        std::cerr << "File does not exist: " << args["queryfile"].as<std::string>() << std::endl;
+    auto queryfile = args["queryfile"].as<std::string>();
+    if(!std::filesystem::exists(queryfile)) {
+        std::cerr << "File does not exist: " << queryfile << std::endl;
         exit(1);
     }
 
@@ -37,8 +38,9 @@ void intersect::validate(const cxxopts::ParseResult& args) {
         std::cerr << "Error: targetfile is required\n";
         exit(1);
     }
-    if(!std::filesystem::exists(args["targetfile"].as<std::string>())) {
-        std::cerr << "File does not exist: " << args["targetfile"].as<std::string>() << std::endl;
+    auto targetfile = args["targetfile"].as<std::string>();
+    if(!std::filesystem::exists(targetfile)) {
+        std::cerr << "File does not exist: " << targetfile << std::endl;
         exit(1);
     }
 

--- a/include/genogrove/structure/grove/graph_overlay.hpp
+++ b/include/genogrove/structure/grove/graph_overlay.hpp
@@ -181,6 +181,7 @@ class graph_overlay {
 
         auto it = adjacency.find(source);
         if (it != adjacency.end()) {
+            neighbors.reserve(it->second.size());
             for (const auto& e : it->second) {
                 if (predicate(e.metadata)) {
                     neighbors.push_back(e.target);

--- a/src/data_type/genomic_coordinate.cpp
+++ b/src/data_type/genomic_coordinate.cpp
@@ -1,7 +1,7 @@
 #include <genogrove/data_type/genomic_coordinate.hpp>
 #include <algorithm>
+#include <format>
 #include <limits>
-#include <sstream>
 
 namespace genogrove::data_type {
 
@@ -41,9 +41,7 @@ namespace genogrove::data_type {
 
     // String conversion
     std::string genomic_coordinate::to_string() const {
-        std::ostringstream oss;
-        oss << strand << ":" << start << "-" << end;
-        return oss.str();
+        return std::format("{}:{}-{}", strand, start, end);
     }
 
     void genomic_coordinate::serialize(std::ostream& os) const {

--- a/src/io/bam_reader.cpp
+++ b/src/io/bam_reader.cpp
@@ -303,12 +303,13 @@ namespace genogrove::io {
         uint8_t* aux_end = b->data + b->l_data;
 
         while (aux < aux_end) {
+            // Each tag needs at least 3 bytes: 2-char name + 1-byte type
+            if (aux + 3 > aux_end) {
+                break;
+            }
+
             // Tag name (2 chars)
-            char tag[3];
-            tag[0] = static_cast<char>(aux[0]);
-            tag[1] = static_cast<char>(aux[1]);
-            tag[2] = '\0';
-            std::string key(tag);
+            std::string key(reinterpret_cast<const char*>(aux), 2);
 
             aux += 2;
             char type = static_cast<char>(*aux++);


### PR DESCRIPTION
## Summary
- Replace `std::ostringstream` with `std::format` in `genomic_coordinate::to_string()` (resolves overlap between #117 and #172)
- Add `reserve()` to `get_neighbors_if()` filtered neighbors vector
- Simplify BAM tag key construction from 4-line char array to direct `std::string(ptr, 2)`
- Cache redundant `args.as<std::string>()` calls in CLI `intersect.cpp` validation

Closes #172.

## Test plan
- [x] CI passes on all compilers
- [x] Existing `genomic_coordinate` tests validate `to_string()` output unchanged
- [x] BAM reader tag parsing tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Minor optimizations improving string formatting, memory preallocation and caching to reduce overhead.
  * Safer and faster parsing with reduced redundant conversions in CLI paths, improving runtime robustness.

* **Chores**
  * Removed legacy and unused implementations to simplify codebase and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->