### PR TITLE
Add stream validation to structural deserializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Adopt `std::span` for `aggregate()`** (**breaking**): Changed `aggregate()` signature on all key types (`interval`, `genomic_coordinate`, `numeric`, `kmer`) and in the `key_type_base` concept from `const std::vector<T>&` to `std::span<const T>`, allowing callers to pass any contiguous range without copying to a vector ([#116](https://github.com/genogrove/genogrove/issues/116))
 
 ### Fixed
+- **Validate stream state in structural deserializers**: Added `if(!is)` checks after every `is.read()` in `node::deserialize()`, `grove::deserialize()`, `data_registry::deserialize()`, and `serialization_traits<std::string>::deserialize()`, matching the existing pattern in leaf-level deserializers. Added B+ tree invariant bounds on `num_keys` and `num_children` in `node::deserialize()`. Added `order >= 3` validation to grove constructor ([#125](https://github.com/genogrove/genogrove/issues/125))
 - **Documentation: interval uses closed coordinates, not half-open**: Fixed docstrings in `interval` and `genomic_coordinate` that incorrectly described the coordinate system as half-open `[start, end)`. The implementation and tests use closed intervals `[start, end]` where the overlap condition is `max(a.start, b.start) <= min(a.end, b.end)` ([#153](https://github.com/genogrove/genogrove/issues/153))
 
 ### Removed

--- a/include/genogrove/data_type/data_registry.hpp
+++ b/include/genogrove/data_type/data_registry.hpp
@@ -190,6 +190,9 @@ class data_registry {
         // Read entry count
         uint64_t count;
         is.read(reinterpret_cast<char*>(&count), sizeof(count));
+        if (!is) {
+            throw std::runtime_error("Failed to deserialize data_registry: stream error reading count");
+        }
 
         // Read each entry
         inst.storage.reserve(count);

--- a/include/genogrove/data_type/serialization_traits.hpp
+++ b/include/genogrove/data_type/serialization_traits.hpp
@@ -156,8 +156,14 @@ struct serialization_traits<std::string> {
     static std::string deserialize(std::istream& is) {
         uint64_t length;
         is.read(reinterpret_cast<char*>(&length), sizeof(length));
+        if (!is) {
+            throw std::runtime_error("Failed to deserialize string: stream error reading length");
+        }
         std::string value(length, '\0');
-        is.read(&value[0], length);
+        is.read(&value[0], static_cast<std::streamsize>(length));
+        if (!is) {
+            throw std::runtime_error("Failed to deserialize string: stream error reading content");
+        }
         return value;
     }
 };

--- a/include/genogrove/structure/grove/grove.hpp
+++ b/include/genogrove/structure/grove/grove.hpp
@@ -99,7 +99,11 @@ class grove {
      * @brief Construct a grove with specified order
      * @param order Determines the maximum number of k-1 keys and k children per node
      */
-    explicit grove(int order) : order(order) {}
+    explicit grove(int order) : order(order) {
+        if (order < 3) {
+            throw std::out_of_range("grove order must be >= 3");
+        }
+    }
 
     /**
      * @brief Construct a grove with default order of 3
@@ -1053,18 +1057,30 @@ class grove {
     [[nodiscard]] static grove deserialize(std::istream& is) {
         int order;
         is.read(reinterpret_cast<char*>(&order), sizeof(order));
+        if (!is) {
+            throw std::runtime_error("Failed to deserialize grove: stream error reading order");
+        }
         grove g(order);
 
         size_t number_root_nodes;
         is.read(reinterpret_cast<char*>(&number_root_nodes), sizeof(number_root_nodes));
+        if (!is) {
+            throw std::runtime_error("Failed to deserialize grove: stream error reading root node count");
+        }
 
         // Deserialize each root node
         for (size_t i = 0; i < number_root_nodes; ++i) {
             // Read index name
             size_t index_name_length;
             is.read(reinterpret_cast<char*>(&index_name_length), sizeof(index_name_length));
+            if (!is) {
+                throw std::runtime_error("Failed to deserialize grove: stream error reading index name length");
+            }
             std::string index_name(index_name_length, '\0');
             is.read(index_name.data(), static_cast<std::streamsize>(index_name_length));
+            if (!is) {
+                throw std::runtime_error("Failed to deserialize grove: stream error reading index name");
+            }
 
             // Deserialize the tree for this index
             node<key_type, data_type>* root = node<key_type, data_type>::deserialize(is, order);
@@ -1083,6 +1099,9 @@ class grove {
         // Read external keys count
         size_t external_count;
         is.read(reinterpret_cast<char*>(&external_count), sizeof(external_count));
+        if (!is) {
+            throw std::runtime_error("Failed to deserialize grove: stream error reading external key count");
+        }
 
         // Read each external key - directly into external_key_storage
         for (size_t i = 0; i < external_count; ++i) {

--- a/include/genogrove/structure/grove/node.hpp
+++ b/include/genogrove/structure/grove/node.hpp
@@ -393,10 +393,22 @@ node<key_type, data_type>* node<key_type, data_type>::deserialize(std::istream& 
 
     // Read is_leaf flag
     is.read(reinterpret_cast<char*>(&n->is_leaf), sizeof(n->is_leaf));
+    if (!is) {
+        delete n;
+        throw std::runtime_error("Failed to deserialize node: stream error reading is_leaf");
+    }
 
     // Read number of keys
     size_t num_keys;
     is.read(reinterpret_cast<char*>(&num_keys), sizeof(num_keys));
+    if (!is) {
+        delete n;
+        throw std::runtime_error("Failed to deserialize node: stream error reading num_keys");
+    }
+    if (num_keys >= static_cast<size_t>(order)) {
+        delete n;
+        throw std::runtime_error("Failed to deserialize node: num_keys exceeds order");
+    }
 
     // Read each key
     n->keys.reserve(num_keys);
@@ -419,6 +431,14 @@ node<key_type, data_type>* node<key_type, data_type>::deserialize(std::istream& 
     if (!n->is_leaf) {
         size_t num_children;
         is.read(reinterpret_cast<char*>(&num_children), sizeof(num_children));
+        if (!is) {
+            delete n;
+            throw std::runtime_error("Failed to deserialize node: stream error reading num_children");
+        }
+        if (num_children > static_cast<size_t>(order)) {
+            delete n;
+            throw std::runtime_error("Failed to deserialize node: num_children exceeds order");
+        }
 
         n->children.reserve(num_children);
         for (size_t i = 0; i < num_children; ++i) {


### PR DESCRIPTION
## Summary
- Add `if(!is)` stream checks after every `is.read()` in `node::deserialize()`, `grove::deserialize()`, `data_registry::deserialize()`, and `serialization_traits<std::string>::deserialize()` — matching the existing pattern in leaf-level deserializers
- Add B+ tree invariant bounds on `num_keys` (must be `< order`) and `num_children` (must be `<= order`) in `node::deserialize()` with cleanup of partially-constructed node before throwing
- Add `order >= 3` validation to `grove` constructor

Closes #125.

## Test plan
- [x] CI passes — existing serialization round-trip tests validate correctness
- [ ] Error-path tests tracked separately in #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added comprehensive data validation to detect and reject corrupted or malformed files during load operations
  * Improved error detection and reporting throughout the data processing pipeline
  * Enhanced system robustness by enforcing stricter data integrity checks at critical validation points
  * Strengthened error handling to prevent processing of invalid or incomplete data structures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->