### PR TITLE
Deduplicate CI triggers: push on main only, pull_request for PRs

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -1,5 +1,8 @@
 name: CI (macOS)
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -1,5 +1,8 @@
 name: CI (Ubuntu)
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Documentation: interval uses closed coordinates, not half-open**: Fixed docstrings in `interval` and `genomic_coordinate` that incorrectly described the coordinate system as half-open `[start, end)`. The implementation and tests use closed intervals `[start, end]` where the overlap condition is `max(a.start, b.start) <= min(a.end, b.end)` ([#153](https://github.com/genogrove/genogrove/issues/153))
 - **Benchmark CI malformed JSON**: Replaced `--benchmark_format=json | tee` with `--benchmark_out=` + `--benchmark_out_format=json` so console progress lines don't corrupt the JSON output file ([#199](https://github.com/genogrove/genogrove/pull/199))
 - **Benchmark CI improvements**: Limited chart history to last 25 commits and enabled benchmark runs on PRs (without storing results) for validation ([#201](https://github.com/genogrove/genogrove/pull/201))
+- **Deduplicate CI triggers**: Restricted `push` trigger to `main` only in `ci-ubuntu.yml` and `ci-macos.yml`, keeping `pull_request` for PRs — eliminates duplicate CI runs on every PR push ([#202](https://github.com/genogrove/genogrove/pull/202))
 
 ### Removed
 - **Deleted unused `file_entry.hpp`**: Removed the legacy `file_entry` struct from the CLI, which was never used outside a commented-out reference in `index.cpp` ([#153](https://github.com/genogrove/genogrove/issues/153))


### PR DESCRIPTION
## Summary
- Change `on: [push, pull_request]` to `push: main` + `pull_request` in both `ci-ubuntu.yml` and `ci-macos.yml`
- Previously every PR push triggered two identical CI runs (one from `push`, one from `pull_request`)
- Now: PR pushes trigger only `pull_request`, merges to main trigger only `push` — same coverage, half the runs

## Test plan
- [x] This PR itself should only show one set of CI checks (not duplicated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed unused legacy type system code to improve codebase maintainability.
  * Optimized CI workflow triggers to reduce duplicate build runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->