### PR TITLE
Fix resource leaks in IO reader constructors on allocation failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Benchmark CI malformed JSON**: Replaced `--benchmark_format=json | tee` with `--benchmark_out=` + `--benchmark_out_format=json` so console progress lines don't corrupt the JSON output file ([#199](https://github.com/genogrove/genogrove/pull/199))
 - **Benchmark CI improvements**: Limited chart history to last 25 commits and enabled benchmark runs on PRs (without storing results) for validation ([#201](https://github.com/genogrove/genogrove/pull/201))
 - **Deduplicate CI triggers**: Restricted `push` trigger to `main` only in `ci-ubuntu.yml` and `ci-macos.yml`, keeping `pull_request` for PRs — eliminates duplicate CI runs on every PR push ([#202](https://github.com/genogrove/genogrove/pull/202))
+- **Fix resource leaks in IO reader constructors**: Wrapped throwing sections of `bam_reader`, `bed_reader`, and `gff_reader` constructors in try/catch to prevent htslib handle and kstring leaks if `std::string`/`std::vector` operations throw `std::bad_alloc` ([#129](https://github.com/genogrove/genogrove/issues/129))
 
 ### Removed
 - **Deleted unused `file_entry.hpp`**: Removed the legacy `file_entry` struct from the CLI, which was never used outside a commented-out reference in `index.cpp` ([#153](https://github.com/genogrove/genogrove/issues/153))

--- a/src/io/bam_reader.cpp
+++ b/src/io/bam_reader.cpp
@@ -40,25 +40,28 @@ namespace genogrove::io {
             throw std::runtime_error("Failed to read header from: " + path.string());
         }
 
-        // Cache header text
-        if (header_->text) {
-            header_text_ = std::string(header_->text, header_->l_text);
-        }
+        // Wrap in try/catch: if std::string/vector operations throw (e.g. bad_alloc),
+        // the constructor hasn't completed so the destructor won't run — clean up manually.
+        try {
+            // Cache header text
+            if (header_->text) {
+                header_text_ = std::string(header_->text, header_->l_text);
+            }
 
-        // Cache reference names
-        ref_names_.reserve(header_->n_targets);
-        for (int i = 0; i < header_->n_targets; ++i) {
-            ref_names_.emplace_back(header_->target_name[i]);
-        }
+            // Cache reference names
+            ref_names_.reserve(header_->n_targets);
+            for (int i = 0; i < header_->n_targets; ++i) {
+                ref_names_.emplace_back(header_->target_name[i]);
+            }
 
-        // Allocate reusable alignment structure
-        alignment_ = bam_init1();
-        if (!alignment_) {
-            bam_hdr_destroy(header_);
-            hts_close(sam_file_);
-            header_ = nullptr;
-            sam_file_ = nullptr;
-            throw std::runtime_error("Failed to allocate alignment structure");
+            // Allocate reusable alignment structure
+            alignment_ = bam_init1();
+            if (!alignment_) {
+                throw std::runtime_error("Failed to allocate alignment structure");
+            }
+        } catch (...) {
+            cleanup();
+            throw;
         }
     }
 

--- a/src/io/bed_reader.cpp
+++ b/src/io/bed_reader.cpp
@@ -53,61 +53,64 @@ namespace genogrove::io {
          * Subsequent lines (if they are invalid are caught by read_next) */
         int64_t start_pos = bgzf_tell(bgzf_file);
         kstring_t str = {0, 0, nullptr};
-        int ret;
-        bool found_data = false;
 
-        // 2. Iterate until we find a data line or EOF
-        while ((ret = bgzf_getline(bgzf_file, '\n', &str)) >= 0) {
-            std::string line(str.s);
+        // Wrap validation in try/catch: std::string(str.s) can throw bad_alloc
+        // after bgzf_getline allocated str.s, leaking both str.s and bgzf_file.
+        try {
+            int ret;
+            bool found_data = false;
 
-            // Skip empty or commented lines (matches read_next logic)
-            if (line.empty() || line[0] == '#') {
-                continue;
-            }
+            // Iterate until we find a data line or EOF
+            while ((ret = bgzf_getline(bgzf_file, '\n', &str)) >= 0) {
+                std::string line(str.s);
 
-            // 3. Attempt to parse the first data line found
-            std::stringstream ss(line);
-            std::string chrom, start, end;
+                // Skip empty or commented lines (matches read_next logic)
+                if (line.empty() || line[0] == '#') {
+                    continue;
+                }
 
-            // Check for minimal BED3 columns
-            if (!(ss >> chrom >> start >> end)) {
-                if (str.s) free(str.s);
-                bgzf_close(bgzf_file); // Clean up before throw
-                throw std::runtime_error("Invalid BED header/format in " + fpath.string());
-            }
+                // Attempt to parse the first data line found
+                std::stringstream ss(line);
+                std::string chrom, start, end;
 
-            // Validate coordinates are integers
-            if (start.empty() || end.empty() ||
-                !std::ranges::all_of(start, ggu::is_digit) ||
-                !std::ranges::all_of(end, ggu::is_digit)) {
-                    if(str.s) free(str.s);
-                    bgzf_close(bgzf_file);
+                // Check for minimal BED3 columns
+                if (!(ss >> chrom >> start >> end)) {
+                    throw std::runtime_error("Invalid BED header/format in " + fpath.string());
+                }
+
+                // Validate coordinates are integers
+                if (start.empty() || end.empty() ||
+                    !std::ranges::all_of(start, ggu::is_digit) ||
+                    !std::ranges::all_of(end, ggu::is_digit)) {
                     throw std::runtime_error("Invalid BED coordinates (non-integer) in " + fpath.string());
+                }
+                // validate start < end
+                size_t start_num = std::stoul(start);
+                size_t end_num = std::stoul(end);
+                if(start_num >= end_num) {
+                    throw std::runtime_error("Invalid BED coordinates (start > end) in " + fpath.string());
+                }
+                found_data = true;
+                break; // Valid line found, stop scanning
             }
-            // validate start < end
-            size_t start_num = std::stoul(start);
-            size_t end_num = std::stoul(end);
-            if(start_num >= end_num) {
-                if(str.s) free(str.s);
-                bgzf_close(bgzf_file);
-                throw std::runtime_error("Invalid BED coordinates (start > end) in " + fpath.string());
+
+            free(str.s);
+            str.s = nullptr;
+
+            // ensure that we found at least one valid BED line
+            if (!found_data) {
+                throw std::runtime_error("No valid BED data found in " + fpath.string());
             }
-            found_data = true;
-            break; // Valid line found, stop scanning
-        }
 
-        if (str.s) free(str.s);
-
-        // ensure that we found at least one valid BED line
-        if (!found_data) {
+            // reset file pointer to the beginning for standard reading
+            if (bgzf_seek(bgzf_file, start_pos, SEEK_SET) < 0) {
+                throw std::runtime_error("Failed to seek back to start of file: " + fpath.string());
+            }
+        } catch (...) {
+            free(str.s);
             bgzf_close(bgzf_file);
-            throw std::runtime_error("No valid BED data found in " + fpath.string());
-        }
-
-        // reset file pointer to the beginning for standard reading
-        if (bgzf_seek(bgzf_file, start_pos, SEEK_SET) < 0) {
-            bgzf_close(bgzf_file);
-            throw std::runtime_error("Failed to seek back to start of file: " + fpath.string());
+            bgzf_file = nullptr;
+            throw;
         }
     }
 

--- a/src/io/gff_reader.cpp
+++ b/src/io/gff_reader.cpp
@@ -83,64 +83,67 @@ namespace genogrove::io {
         // Store start position
         int64_t start_pos = bgzf_tell(bgzf_file);
         kstring_t str = {0, 0, nullptr};
-        int ret;
-        bool found_data = false;
 
-        // Iterate until we find a data line or EOF
-        while ((ret = bgzf_getline(bgzf_file, '\n', &str)) >= 0) {
-            std::string line(str.s);
+        // Wrap validation in try/catch: std::string(str.s) can throw bad_alloc
+        // after bgzf_getline allocated str.s, leaking both str.s and bgzf_file.
+        try {
+            int ret;
+            bool found_data = false;
 
-            // Skip empty lines and comments/directives (matches read_next logic)
-            if (line.empty() || line[0] == '#') {
-                continue;
+            // Iterate until we find a data line or EOF
+            while ((ret = bgzf_getline(bgzf_file, '\n', &str)) >= 0) {
+                std::string line(str.s);
+
+                // Skip empty lines and comments/directives (matches read_next logic)
+                if (line.empty() || line[0] == '#') {
+                    continue;
+                }
+
+                // Attempt to parse the first data line found
+                std::stringstream ss(line);
+                std::string seqid, source, type, start_str, end_str, score_str, strand_str, phase_str;
+
+                // Check for minimal GFF columns (8 required + attributes)
+                if (!(ss >> seqid >> source >> type >> start_str >> end_str >> score_str >> strand_str >> phase_str)) {
+                    throw std::runtime_error("Invalid GFF header/format in " + fpath.string());
+                }
+
+                // Validate coordinates are integers
+                if (start_str.empty() || end_str.empty() ||
+                    !std::ranges::all_of(start_str, ggu::is_digit) ||
+                    !std::ranges::all_of(end_str, ggu::is_digit)) {
+                    throw std::runtime_error("Invalid GFF coordinates (non-integer) in " + fpath.string());
+                }
+
+                // Validate start < end (GFF is 1-based inclusive, so convert to 0-based)
+                size_t start_num = std::stoul(start_str) - 1;  // Convert to 0-based
+                size_t end_num = std::stoul(end_str);          // End becomes exclusive
+
+                if (start_num >= end_num) {
+                    throw std::runtime_error("Invalid GFF coordinates (start >= end) in " + fpath.string());
+                }
+
+                found_data = true;
+                break; // Valid line found, stop scanning
             }
 
-            // Attempt to parse the first data line found
-            std::stringstream ss(line);
-            std::string seqid, source, type, start_str, end_str, score_str, strand_str, phase_str;
+            free(str.s);
+            str.s = nullptr;
 
-            // Check for minimal GFF columns (8 required + attributes)
-            if (!(ss >> seqid >> source >> type >> start_str >> end_str >> score_str >> strand_str >> phase_str)) {
-                if (str.s) free(str.s);
-                bgzf_close(bgzf_file);
-                throw std::runtime_error("Invalid GFF header/format in " + fpath.string());
+            // Ensure that we found at least one valid GFF line
+            if (!found_data) {
+                throw std::runtime_error("No valid GFF data found in " + fpath.string());
             }
 
-            // Validate coordinates are integers
-            if (start_str.empty() || end_str.empty() ||
-                !std::ranges::all_of(start_str, ggu::is_digit) ||
-                !std::ranges::all_of(end_str, ggu::is_digit)) {
-                if (str.s) free(str.s);
-                bgzf_close(bgzf_file);
-                throw std::runtime_error("Invalid GFF coordinates (non-integer) in " + fpath.string());
+            // Reset file pointer to the beginning for standard reading
+            if (bgzf_seek(bgzf_file, start_pos, SEEK_SET) < 0) {
+                throw std::runtime_error("Failed to seek back to start of file: " + fpath.string());
             }
-
-            // Validate start < end (GFF is 1-based inclusive, so convert to 0-based)
-            size_t start_num = std::stoul(start_str) - 1;  // Convert to 0-based
-            size_t end_num = std::stoul(end_str);          // End becomes exclusive
-
-            if (start_num >= end_num) {
-                if (str.s) free(str.s);
-                bgzf_close(bgzf_file);
-                throw std::runtime_error("Invalid GFF coordinates (start >= end) in " + fpath.string());
-            }
-
-            found_data = true;
-            break; // Valid line found, stop scanning
-        }
-
-        if (str.s) free(str.s);
-
-        // Ensure that we found at least one valid GFF line
-        if (!found_data) {
+        } catch (...) {
+            free(str.s);
             bgzf_close(bgzf_file);
-            throw std::runtime_error("No valid GFF data found in " + fpath.string());
-        }
-
-        // Reset file pointer to the beginning for standard reading
-        if (bgzf_seek(bgzf_file, start_pos, SEEK_SET) < 0) {
-            bgzf_close(bgzf_file);
-            throw std::runtime_error("Failed to seek back to start of file: " + fpath.string());
+            bgzf_file = nullptr;
+            throw;
         }
     }
 


### PR DESCRIPTION
## Summary
- Wrap throwing sections of `bam_reader`, `bed_reader`, and `gff_reader` constructors in try/catch to prevent resource leaks
- **bam_reader**: If `std::string`/`std::vector` operations throw after `sam_file_` and `header_` are acquired, `cleanup()` is now called before rethrowing
- **bed_reader/gff_reader**: If `std::string line(str.s)` throws after `bgzf_getline` allocated `str.s`, both `str.s` and `bgzf_file` are now freed before rethrowing
- Also simplifies bed/gff validation paths by consolidating per-throw manual cleanup into the single catch block

Closes #129.

## Test plan
- [x] Existing IO reader tests pass (construction, iteration, error handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)