### PR TITLE
Add overflow check and in-class initializer to index_registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Benchmark CI improvements**: Limited chart history to last 25 commits and enabled benchmark runs on PRs (without storing results) for validation ([#201](https://github.com/genogrove/genogrove/pull/201))
 - **Deduplicate CI triggers**: Restricted `push` trigger to `main` only in `ci-ubuntu.yml` and `ci-macos.yml`, keeping `pull_request` for PRs — eliminates duplicate CI runs on every PR push ([#202](https://github.com/genogrove/genogrove/pull/202))
 - **Fix resource leaks in IO reader constructors**: Wrapped throwing sections of `bam_reader`, `bed_reader`, and `gff_reader` constructors in try/catch to prevent htslib handle and kstring leaks if `std::string`/`std::vector` operations throw `std::bad_alloc` ([#129](https://github.com/genogrove/genogrove/issues/129))
+- **Prevent `index_registry` overflow**: Added overflow check that throws `std::runtime_error` when capacity (255) is exceeded, and added in-class initializer for `next_index` ([#130](https://github.com/genogrove/genogrove/issues/130))
 
 ### Removed
 - **Deleted unused `file_entry.hpp`**: Removed the legacy `file_entry` struct from the CLI, which was never used outside a commented-out reference in `index.cpp` ([#153](https://github.com/genogrove/genogrove/issues/153))

--- a/include/genogrove/data_type/index_registry.hpp
+++ b/include/genogrove/data_type/index_registry.hpp
@@ -58,7 +58,7 @@ namespace genogrove::data_type {
 
         private:
             std::unordered_map<std::string, uint8_t> registry;
-            uint8_t next_index;
+            uint8_t next_index{0};
     };
 }
 

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -1,5 +1,7 @@
 #include <genogrove/data_type/index_registry.hpp>
 
+#include <limits>
+
 namespace genogrove::data_type {
 
     index_registry &index_registry::instance() {
@@ -10,6 +12,9 @@ namespace genogrove::data_type {
     uint8_t index_registry::register_key(const std::string &key) {
         std::optional<uint8_t> idx = ggu::value_lookup(this->registry, key);
         if(!idx.has_value()) {
+            if (next_index == std::numeric_limits<uint8_t>::max()) {
+                throw std::runtime_error("index_registry: maximum capacity (255) exceeded");
+            }
             uint8_t new_index = this->next_index++;
             this->registry.insert({key, new_index});
             return new_index;


### PR DESCRIPTION
## Summary
- Add overflow check in `register_key()` that throws `std::runtime_error` when the `uint8_t` capacity (255 entries) is exceeded, instead of silently wrapping to 0 and overwriting previous entries
- Add in-class initializer `uint8_t next_index{0}` (previously relied on static storage duration for zero-initialization)

Closes #130.

## Test plan
- [x] Existing index_registry tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added capacity overflow detection to the index registration system. When the maximum capacity of 255 indices is exceeded, the system now throws a clear error instead of allowing undefined behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->