### PR TITLE
Fix O(n) linear scan in value_lookup(), add reverse map to index_registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Remove legacy type erasure code**: Deleted `any_type.hpp`, `type_registry.hpp`, and `type_registry.cpp` — unused since the library moved from runtime type erasure to compile-time templates. Cleaned up dead includes from `key.hpp` and `query_result.hpp`
 
 ### Performance
+- **Fix O(n) linear scan in `value_lookup()`**: Replaced `std::ranges::find` with `container.find()` in the generic `value_lookup()` utility, giving O(1) amortized lookups on `unordered_map` (previously O(n)). Added a reverse lookup vector to `index_registry` so `key_lookup()` is O(1) instead of O(n) linear scan ([#164](https://github.com/genogrove/genogrove/issues/164))
 - **Minor performance improvements**: Replaced `std::ostringstream` with `std::format` in `genomic_coordinate::to_string()`, added `reserve()` to `get_neighbors_if()`, simplified BAM tag key construction, and cached redundant `args.as<std::string>()` calls in CLI `intersect.cpp` ([#172](https://github.com/genogrove/genogrove/issues/172))
 
 ## [0.16.0] - 2026-03-01

--- a/include/genogrove/data_type/index_registry.hpp
+++ b/include/genogrove/data_type/index_registry.hpp
@@ -13,8 +13,10 @@
 // Standard
 #include <bitset>
 #include <cstdint>
+#include <string>
 #include <string_view>
 #include <unordered_map>
+#include <vector>
 #include <stdexcept>
 #include <optional>
 #include <iostream>
@@ -58,6 +60,7 @@ namespace genogrove::data_type {
 
         private:
             std::unordered_map<std::string, uint8_t> registry;
+            std::vector<std::string> reverse_registry;
             uint8_t next_index{0};
     };
 }

--- a/include/genogrove/utility/ranges.hpp
+++ b/include/genogrove/utility/ranges.hpp
@@ -12,6 +12,7 @@
 #include <ranges>
 #include <algorithm>
 #include <optional>
+#include <type_traits>
 
 namespace genogrove::utility {
     namespace ranges = std::ranges;
@@ -50,10 +51,15 @@ namespace genogrove::utility {
             && requires { typename AssocContainer::key_type; typename AssocContainer::mapped_type; })
     auto value_lookup(const AssocContainer& container, const Key& key)
     -> std::optional<typename AssocContainer::mapped_type> {
-        auto it = genogrove::utility::ranges::find(container, key, [](const auto &p) {
-            return p.first;
-        });
-        if (it != genogrove::utility::ranges::end(container)) {
+        auto do_find = [&]() {
+            if constexpr (std::is_same_v<Key, typename AssocContainer::key_type>) {
+                return container.find(key);
+            } else {
+                return container.find(typename AssocContainer::key_type(key));
+            }
+        };
+        auto it = do_find();
+        if (it != container.end()) {
             return it->second;
         }
         return std::nullopt;

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -17,6 +17,7 @@ namespace genogrove::data_type {
             }
             uint8_t new_index = this->next_index++;
             this->registry.insert({key, new_index});
+            this->reverse_registry.push_back(key);
             return new_index;
         }
         return idx.value();
@@ -27,7 +28,10 @@ namespace genogrove::data_type {
     }
 
     std::optional<std::string> index_registry::key_lookup(uint8_t value) const {
-        return ggu::key_lookup(this->registry, value);
+        if (value < reverse_registry.size()) {
+            return reverse_registry[value];
+        }
+        return std::nullopt;
     }
 
     std::optional<uint8_t> index_registry::value_lookup(std::string_view key) const {


### PR DESCRIPTION
## Summary
- **`value_lookup()`**: Replace `std::ranges::find` (O(n) linear scan) with `container.find()` (O(1) amortized for `unordered_map`). This function is called on every `insert()`, `intersect()`, `insert_sorted()`, and `build_tree_bottom_up()` via `grove::get_root()` and `grove::get_rightmost_node()`
- **`index_registry::key_lookup()`**: Add a `std::vector<std::string>` reverse map so reverse lookups are O(1) array indexing instead of O(n) linear scan through the map

Closes #164.

## Test plan
- [x] Existing `ranges-test` and `index_test` pass (same API, same semantics)
- [x] All grove/structure tests pass (value_lookup is on every hot path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Faster value lookups by using more efficient lookup methods for associative containers.
  * Key-to-name resolution now uses a direct reverse mapping, making index-to-key lookups O(1).
  * Overall registry operations are optimized for reduced latency and improved responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->