### PR TITLE
Eliminate std::string allocations on grove map lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 - **Fix O(n) linear scan in `value_lookup()`**: Replaced `std::ranges::find` with `container.find()` in the generic `value_lookup()` utility, giving O(1) amortized lookups on `unordered_map` (previously O(n)). Added a reverse lookup vector to `index_registry` so `key_lookup()` is O(1) instead of O(n) linear scan ([#164](https://github.com/genogrove/genogrove/issues/164))
+- **Eliminate `std::string` allocations on grove map lookups**: Added transparent `string_hash` and `std::equal_to<>` to grove's `root_nodes` and `rightmost_nodes` maps, enabling direct `string_view` lookup without constructing a temporary `std::string`. Updated `value_lookup()` to detect transparent containers via `requires` and skip key conversion automatically ([#165](https://github.com/genogrove/genogrove/issues/165))
 - **Minor performance improvements**: Replaced `std::ostringstream` with `std::format` in `genomic_coordinate::to_string()`, added `reserve()` to `get_neighbors_if()`, simplified BAM tag key construction, and cached redundant `args.as<std::string>()` calls in CLI `intersect.cpp` ([#172](https://github.com/genogrove/genogrove/issues/172))
 
 ## [0.16.0] - 2026-03-01

--- a/include/genogrove/structure/grove/grove.hpp
+++ b/include/genogrove/structure/grove/grove.hpp
@@ -29,6 +29,17 @@ namespace gdt = genogrove::data_type;
 
 namespace genogrove::structure {
     /**
+     * @brief Transparent hash for std::string keys, enabling lookup with std::string_view
+     *        without allocating a temporary std::string.
+     */
+    struct string_hash {
+        using is_transparent = void;
+        size_t operator()(std::string_view sv) const noexcept {
+            return std::hash<std::string_view>{}(sv);
+        }
+    };
+
+    /**
      * @brief Tag type for dispatching to sorted insertion algorithm
      * @note Use this when inserting data that is already sorted for optimal performance
      * @see grove::insert_data(std::string_view, key_type, data_type, sorted_t)
@@ -450,7 +461,7 @@ class grove {
      * @brief Get map of all root nodes indexed by their string keys
      * @return Unordered map from index names (e.g., chromosome names) to root node pointers
      */
-    std::unordered_map<std::string, node<key_type, data_type>*> get_root_nodes() const {
+    std::unordered_map<std::string, node<key_type, data_type>*, string_hash, std::equal_to<>> get_root_nodes() const {
         return this->root_nodes;
     }
 
@@ -459,7 +470,7 @@ class grove {
      * @param root_nodes New map of root nodes to use
      * @note This deletes all existing root nodes and clears rightmost node cache
      */
-    void set_root_nodes(std::unordered_map<std::string, node<key_type, data_type>*> root_nodes) {
+    void set_root_nodes(std::unordered_map<std::string, node<key_type, data_type>*, string_hash, std::equal_to<>> root_nodes) {
         for(auto& [_, root] : this->root_nodes) {
             delete root;
         }
@@ -474,7 +485,7 @@ class grove {
      * @note Used for optimized sorted insertion
      */
     node<key_type, data_type>* get_rightmost_node(std::string_view key) {
-        return ggu::value_lookup(this->rightmost_nodes, std::string(key)).value_or(nullptr);
+        return ggu::value_lookup(this->rightmost_nodes, key).value_or(nullptr);
     }
 
     /**
@@ -493,7 +504,7 @@ class grove {
      * @return Pointer to root node, or nullptr if index doesn't exist
      */
     node<key_type, data_type>* get_root(std::string_view key) {
-        return ggu::value_lookup(this->root_nodes, std::string(key)).value_or(nullptr);
+        return ggu::value_lookup(this->root_nodes, key).value_or(nullptr);
     }
 
     /**
@@ -1303,10 +1314,10 @@ class grove {
     int order;
 
     /// Map from index names (e.g., chromosome names) to their root nodes
-    std::unordered_map<std::string, node<key_type, data_type>*> root_nodes;
+    std::unordered_map<std::string, node<key_type, data_type>*, string_hash, std::equal_to<>> root_nodes;
 
     /// Cache of rightmost leaf nodes for each index (used for sorted insertion optimization)
-    std::unordered_map<std::string, node<key_type, data_type>*> rightmost_nodes;
+    std::unordered_map<std::string, node<key_type, data_type>*, string_hash, std::equal_to<>> rightmost_nodes;
 
     /// Deque storage for all indexed keys; provides stable pointers and better cache locality than individual allocations
     std::deque<gdt::key<key_type, data_type>> key_storage;

--- a/include/genogrove/utility/ranges.hpp
+++ b/include/genogrove/utility/ranges.hpp
@@ -12,7 +12,6 @@
 #include <ranges>
 #include <algorithm>
 #include <optional>
-#include <type_traits>
 
 namespace genogrove::utility {
     namespace ranges = std::ranges;
@@ -52,7 +51,7 @@ namespace genogrove::utility {
     auto value_lookup(const AssocContainer& container, const Key& key)
     -> std::optional<typename AssocContainer::mapped_type> {
         auto do_find = [&]() {
-            if constexpr (std::is_same_v<Key, typename AssocContainer::key_type>) {
+            if constexpr (requires { container.find(key); }) {
                 return container.find(key);
             } else {
                 return container.find(typename AssocContainer::key_type(key));


### PR DESCRIPTION
## Summary
- Add transparent `string_hash` with `is_transparent` and `std::equal_to<>` to grove's `root_nodes` and `rightmost_nodes` maps, enabling `find(string_view)` without allocating a temporary `std::string`
- Remove `std::string(key)` conversions from the two hot-path lookups: `get_root()` and `get_rightmost_node()` (called on every insert/intersect/bulk-insert)
- Update `value_lookup()` to detect transparent containers via `requires { container.find(key); }` instead of `is_same_v`, so the direct find path is used automatically

**Breaking**: `get_root_nodes()` return type and `set_root_nodes()` parameter type now include the transparent hash/equal template arguments. Callers using `auto` are unaffected.

Closes #165.

## Test plan
- [x] All grove/structure tests pass
- [x] Serialization round-trip tests pass (map type doesn't affect serialized format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)