### PR TITLE
Complete index_registry singleton pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Encapsulate grove and node internals**: Moved grove tree-manipulation methods (`set_rightmost_node()`, `get_root()`, `insert_root()`, `insert_iter()`, `split_node()`, `insert_data_sorted()`, `insert_sorted()`, `search_iter()`) to `private`. Removed `set_order()` from both `grove` and `node` — order is immutable after construction. ([#155](https://github.com/genogrove/genogrove/issues/155), [#227](https://github.com/genogrove/genogrove/pull/227))
 - **Forward base class in IO reader move operations**: `bed_reader`, `gff_reader`, and `bam_reader` move constructors and move assignment operators now invoke the `file_reader<EntryType>` base class move constructor/assignment, preventing silent state loss if the base ever gains data members. ([#148](https://github.com/genogrove/genogrove/issues/148), [#225](https://github.com/genogrove/genogrove/pull/225))
 
+### Fixed
+- **Complete `index_registry` singleton pattern**: Made constructor private and deleted copy/move operations to prevent bypassing the singleton, matching the `data_registry` pattern. ([#147](https://github.com/genogrove/genogrove/issues/147), [#228](https://github.com/genogrove/genogrove/pull/228))
+
 ### Changed
 - **`data_registry::get()` returns references instead of raw pointers** (**breaking**): `get()` now returns `const T&` / `T&` and throws `std::out_of_range` on invalid IDs instead of returning `nullptr`. Internal storage switched from `std::vector` to `std::deque` for reference stability across `register_data()` calls. Use `contains()` to check validity before calling `get()`. ([#143](https://github.com/genogrove/genogrove/issues/143), [#226](https://github.com/genogrove/genogrove/pull/226))
 

--- a/include/genogrove/data_type/index_registry.hpp
+++ b/include/genogrove/data_type/index_registry.hpp
@@ -36,6 +36,12 @@ namespace genogrove::data_type {
              * Singleton to make sure that only one instance of the registry is created
              */
             static index_registry& instance();
+
+            // Non-copyable, non-movable (singleton)
+            index_registry(const index_registry&) = delete;
+            index_registry& operator=(const index_registry&) = delete;
+            index_registry(index_registry&&) = delete;
+            index_registry& operator=(index_registry&&) = delete;
             /*
              * @brief registers a string as an index - does nothing if the
              */
@@ -59,6 +65,7 @@ namespace genogrove::data_type {
             std::optional<uint8_t> value_lookup(std::string_view key) const;
 
         private:
+            index_registry() = default;
             std::unordered_map<std::string, uint8_t> registry;
             std::vector<std::string> reverse_registry;
             uint8_t next_index{0};


### PR DESCRIPTION
## Summary
- Make `index_registry` constructor private to prevent direct instantiation
- Delete copy/move constructors and assignment operators to prevent singleton bypass
- Matches the `data_registry` singleton pattern

Closes #147

## Test plan
- [x] Build with `BUILD_TESTING=ON` and run `ctest`
- [x] Verify no code constructs `index_registry` directly (only `instance()` is used)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enforced singleton behavior for the index registry to prevent multiple instances, improving stability and preventing accidental duplication.
  * Aligns registry handling with existing patterns for more predictable lifecycle and safer use across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->