### PR TITLE
Add query_result test coverage and IO error checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`query_result` test coverage**: Added 6 new tests covering void `data_type`, empty results, key insertion-order preservation, `numeric` keys, `genomic_coordinate` keys with string data, and null key rejection ([#174](https://github.com/genogrove/genogrove/issues/174), [#238](https://github.com/genogrove/genogrove/pull/238))
+- **IO reader error-message checks after iteration**: Added `get_error_message().empty()` assertions after all range-for loops in BED (10), GFF (8), and BAM (22) reader tests to enforce the iterator error-checking contract ([#178](https://github.com/genogrove/genogrove/issues/178), [#238](https://github.com/genogrove/genogrove/pull/238))
 - **Error-path test coverage**: Added 28 tests covering previously untested error paths — serialization/deserialization failure for all key types and `registry` (empty stream, truncated stream, failed stream), node `add_child`/`get_child` out-of-range, grove `intersect` on non-existent index, filetype detector on non-existent file, BAM reader empty SAM file and `get_error_message()` after iteration, and utility `value_lookup`/`key_lookup` for missing entries ([#137](https://github.com/genogrove/genogrove/issues/137), [#222](https://github.com/genogrove/genogrove/pull/222))
 
 ### Refactored

--- a/tests/data_type/query_result-test.cpp
+++ b/tests/data_type/query_result-test.cpp
@@ -16,6 +16,8 @@
 // genogrove
 #include <genogrove/data_type/query_result.hpp>
 #include <genogrove/data_type/interval.hpp>
+#include <genogrove/data_type/numeric.hpp>
+#include <genogrove/data_type/genomic_coordinate.hpp>
 
 namespace gdt = genogrove::data_type;
 
@@ -62,4 +64,87 @@ TEST(query_result_test, add_keys_with_data) {
     EXPECT_EQ(keys[0]->get_data(), 5);
     EXPECT_EQ(keys[1]->get_data(), 15);
     EXPECT_EQ(keys[2]->get_data(), 18);
+}
+
+TEST(query_result_test, void_data_type) {
+    gdt::interval query_interval(10, 20);
+    gdt::query_result<gdt::interval> results(query_interval);
+
+    gdt::key<gdt::interval> key0(gdt::interval(5, 15));
+    gdt::key<gdt::interval> key1(gdt::interval(12, 22));
+
+    results.add_key(&key0);
+    results.add_key(&key1);
+
+    EXPECT_EQ(results.get_query(), query_interval);
+    EXPECT_EQ(results.get_keys().size(), 2);
+    EXPECT_EQ(results.get_keys()[0]->get_value(), gdt::interval(5, 15));
+    EXPECT_EQ(results.get_keys()[1]->get_value(), gdt::interval(12, 22));
+}
+
+TEST(query_result_test, empty_result) {
+    gdt::interval query_interval(100, 200);
+    gdt::query_result<gdt::interval, int> results(query_interval);
+
+    EXPECT_EQ(results.get_query(), query_interval);
+    EXPECT_TRUE(results.get_keys().empty());
+    EXPECT_EQ(results.get_keys().size(), 0);
+}
+
+TEST(query_result_test, key_ordering_preserved) {
+    gdt::interval query_interval(0, 100);
+    gdt::query_result<gdt::interval> results(query_interval);
+
+    gdt::key<gdt::interval> key0(gdt::interval(50, 60));
+    gdt::key<gdt::interval> key1(gdt::interval(10, 20));
+    gdt::key<gdt::interval> key2(gdt::interval(80, 90));
+
+    // Insert in non-sorted order — result should preserve insertion order
+    results.add_key(&key0);
+    results.add_key(&key1);
+    results.add_key(&key2);
+
+    auto keys = results.get_keys();
+    ASSERT_EQ(keys.size(), 3);
+    EXPECT_EQ(keys[0]->get_value(), gdt::interval(50, 60));
+    EXPECT_EQ(keys[1]->get_value(), gdt::interval(10, 20));
+    EXPECT_EQ(keys[2]->get_value(), gdt::interval(80, 90));
+}
+
+TEST(query_result_test, with_numeric_key) {
+    gdt::numeric query_val(42);
+    gdt::query_result<gdt::numeric> results(query_val);
+
+    gdt::key<gdt::numeric> key0(gdt::numeric(42));
+    results.add_key(&key0);
+
+    EXPECT_EQ(results.get_query(), query_val);
+    ASSERT_EQ(results.get_keys().size(), 1);
+    EXPECT_EQ(results.get_keys()[0]->get_value(), gdt::numeric(42));
+}
+
+TEST(query_result_test, with_genomic_coordinate_key) {
+    gdt::genomic_coordinate query_coord('+', 100, 200);
+    gdt::query_result<gdt::genomic_coordinate, std::string> results(query_coord);
+
+    gdt::key<gdt::genomic_coordinate, std::string> key0(
+        gdt::genomic_coordinate('+', 90, 150), "exon1");
+    gdt::key<gdt::genomic_coordinate, std::string> key1(
+        gdt::genomic_coordinate('+', 180, 250), "exon2");
+
+    results.add_key(&key0);
+    results.add_key(&key1);
+
+    EXPECT_EQ(results.get_query(), query_coord);
+    ASSERT_EQ(results.get_keys().size(), 2);
+    EXPECT_EQ(results.get_keys()[0]->get_data(), "exon1");
+    EXPECT_EQ(results.get_keys()[1]->get_data(), "exon2");
+}
+
+TEST(query_result_test, add_null_key_throws) {
+    gdt::interval query_interval(10, 20);
+    gdt::query_result<gdt::interval> results(query_interval);
+
+    EXPECT_THROW(results.add_key(nullptr), std::invalid_argument);
+    EXPECT_TRUE(results.get_keys().empty());
 }

--- a/tests/io/bamfile-test.cpp
+++ b/tests/io/bamfile-test.cpp
@@ -62,6 +62,7 @@ TEST_F(BamReaderTest, ReadSamFile) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     // We have 9 records in test.sam, but default options skip unmapped (read004)
     ASSERT_EQ(entries.size(), 8);
@@ -74,6 +75,7 @@ TEST_F(BamReaderTest, ReadSamFileIncludeAll) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     // All 9 records including unmapped
     ASSERT_EQ(entries.size(), 9);
@@ -103,6 +105,7 @@ TEST_F(BamReaderTest, VerifyReverseStrandAlignment) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     // Find the reverse strand read (read003)
     auto it = std::find_if(entries.begin(), entries.end(),
@@ -138,6 +141,7 @@ TEST_F(BamReaderTest, ParseComplexCigar) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     // Find read002 with 30M10I10M CIGAR
     auto it = std::find_if(entries.begin(), entries.end(),
@@ -169,6 +173,7 @@ TEST_F(BamReaderTest, ParseCigarWithDeletion) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     // Find read003 with 25M5D25M CIGAR
     auto it = std::find_if(entries.begin(), entries.end(),
@@ -197,6 +202,7 @@ TEST_F(BamReaderTest, ParseCigarWithSkip) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     // Find read007 with 20M100N30M CIGAR (spliced alignment)
     auto it = std::find_if(entries.begin(), entries.end(),
@@ -220,6 +226,7 @@ TEST_F(BamReaderTest, ParseCigarWithSoftClipping) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     // Find read006 with 10S30M10S CIGAR
     auto it = std::find_if(entries.begin(), entries.end(),
@@ -282,6 +289,7 @@ TEST_F(BamReaderTest, ParseCharacterTag) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     // Find read003 which has XS:A:+ tag
     auto it = std::find_if(entries.begin(), entries.end(),
@@ -301,6 +309,7 @@ TEST_F(BamReaderTest, MultipleTags) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     // Find read008 which has many tags
     auto it = std::find_if(entries.begin(), entries.end(),
@@ -341,6 +350,7 @@ TEST_F(BamReaderTest, NoMateInfoForUnpairedRead) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     // Find read002 which is unpaired
     auto it = std::find_if(entries.begin(), entries.end(),
@@ -362,6 +372,7 @@ TEST_F(BamReaderTest, FlagMethods) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     // Find unmapped read (read004)
     auto unmapped = std::find_if(entries.begin(), entries.end(),
@@ -397,6 +408,7 @@ TEST_F(BamReaderTest, FilterUnmappedReads) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     // All entries should be mapped
     for (const auto& entry : entries) {
@@ -411,6 +423,7 @@ TEST_F(BamReaderTest, PrimaryOnlyFilter) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     // All entries should be primary
     for (const auto& entry : entries) {
@@ -438,6 +451,7 @@ TEST_F(BamReaderTest, MapqFilter) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     // All entries should have MAPQ >= 30
     for (const auto& entry : entries) {
@@ -515,6 +529,7 @@ TEST_F(BamReaderTest, IteratorBasicIteration) {
     for (const auto& entry : reader) {
         read_names.push_back(entry.qname);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     EXPECT_EQ(read_names.size(), 8);
     EXPECT_EQ(read_names[0], "read001");
@@ -603,6 +618,7 @@ TEST_F(BamReaderTest, EmptySamFileHeaderOnly) {
     for ([[maybe_unused]] const auto& e : reader2) {
         count++;
     }
+    EXPECT_TRUE(reader2.get_error_message().empty()) << "Unexpected error: " << reader2.get_error_message();
     EXPECT_EQ(count, 0);
 
     fs::remove(empty_sam);
@@ -743,6 +759,7 @@ TEST_F(BamReaderTest, ReadBamFile) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     // Same as SAM: 9 records, default options skip unmapped (read004)
     ASSERT_EQ(entries.size(), 8);
@@ -755,6 +772,7 @@ TEST_F(BamReaderTest, BamFileContentMatchesSam) {
     for (const auto& entry : sam_reader) {
         sam_entries.push_back(entry);
     }
+    EXPECT_TRUE(sam_reader.get_error_message().empty()) << "Unexpected error: " << sam_reader.get_error_message();
 
     // Read all entries from BAM
     gio::bam_reader bam_reader(bam_path);
@@ -762,6 +780,7 @@ TEST_F(BamReaderTest, BamFileContentMatchesSam) {
     for (const auto& entry : bam_reader) {
         bam_entries.push_back(entry);
     }
+    EXPECT_TRUE(bam_reader.get_error_message().empty()) << "Unexpected error: " << bam_reader.get_error_message();
 
     // Should have same number of entries
     ASSERT_EQ(sam_entries.size(), bam_entries.size());
@@ -809,6 +828,7 @@ TEST_F(BamReaderTest, BamFileIncludeAll) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     // All 9 records including unmapped
     ASSERT_EQ(entries.size(), 9);
@@ -821,6 +841,7 @@ TEST_F(BamReaderTest, BamFilePrimaryOnly) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     // All entries should be primary
     for (const auto& entry : entries) {
@@ -854,6 +875,7 @@ TEST_F(BamReaderTest, BamFileCigarParsing) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     // Find read002 with 30M10I10M CIGAR
     auto it = std::find_if(entries.begin(), entries.end(),

--- a/tests/io/bedfile-test.cpp
+++ b/tests/io/bedfile-test.cpp
@@ -76,6 +76,7 @@ TEST_F(bedfileTest, readBED3Format) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     ASSERT_EQ(entries.size(), 3);
 
@@ -109,6 +110,7 @@ TEST_F(bedfileTest, readBED6Format) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     ASSERT_EQ(entries.size(), 3);
 
@@ -147,6 +149,7 @@ TEST_F(bedfileTest, readBED12Format) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     ASSERT_EQ(entries.size(), 3);
 
@@ -397,6 +400,7 @@ TEST_F(bedfileTest, readGzippedBED3Format) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     ASSERT_EQ(entries.size(), 3);
 
@@ -426,6 +430,7 @@ TEST_F(bedfileTest, readGzippedBED6Format) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     ASSERT_EQ(entries.size(), 3);
 
@@ -460,6 +465,7 @@ TEST_F(bedfileTest, readGzippedBED12Format) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     ASSERT_EQ(entries.size(), 3);
 
@@ -512,6 +518,7 @@ TEST_F(bedfileTest, iteratorBasicIteration) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     ASSERT_EQ(entries.size(), 3);
 
@@ -549,6 +556,7 @@ TEST_F(bedfileTest, iteratorWithOptionalFields) {
             EXPECT_EQ(entry.strand.value(), '+');
         }
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     EXPECT_EQ(count, 3);
 }
@@ -614,6 +622,7 @@ TEST_F(bedfileTest, mixedBedFormatsNoStaleOptionals) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     ASSERT_EQ(entries.size(), 3);
 
@@ -664,6 +673,7 @@ TEST_F(bedfileTest, iteratorGzippedFile) {
     for (const auto& entry : reader) {
         chroms.push_back(entry.chrom);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     ASSERT_EQ(chroms.size(), 3);
     EXPECT_EQ(chroms[0], "chr1");

--- a/tests/io/gfffile-test.cpp
+++ b/tests/io/gfffile-test.cpp
@@ -77,6 +77,7 @@ TEST_F(gfffileTest, readGFF3Format) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     ASSERT_EQ(entries.size(), 4);
 
@@ -128,6 +129,7 @@ TEST_F(gfffileTest, readGTFFormat) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     ASSERT_EQ(entries.size(), 4);
 
@@ -458,6 +460,7 @@ TEST_F(gfffileTest, readGzippedGFF3Format) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     ASSERT_EQ(entries.size(), 4);
 
@@ -485,6 +488,7 @@ TEST_F(gfffileTest, readGzippedGTFFormat) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     ASSERT_EQ(entries.size(), 4);
 
@@ -646,6 +650,7 @@ TEST_F(gfffileTest, iteratorBasicIteration) {
     for (const auto& entry : reader) {
         entries.push_back(entry);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     ASSERT_EQ(entries.size(), 4);
 
@@ -683,6 +688,7 @@ TEST_F(gfffileTest, iteratorGTFFormat) {
             EXPECT_EQ(gene_id.value(), "ENSG00000001");
         }
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     EXPECT_EQ(count, 4);
 }
@@ -729,6 +735,7 @@ TEST_F(gfffileTest, iteratorGzippedFile) {
     for (const auto& entry : reader) {
         types.push_back(entry.type);
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 
     ASSERT_EQ(types.size(), 4);
     EXPECT_EQ(types[0], "gene");
@@ -750,4 +757,5 @@ TEST_F(gfffileTest, iteratorAccessAttributes) {
             ASSERT_TRUE(id.has_value());
         }
     }
+    EXPECT_TRUE(reader.get_error_message().empty()) << "Unexpected error: " << reader.get_error_message();
 }


### PR DESCRIPTION
## Summary
- **query_result tests (#174)**: Add 6 new test cases covering void data_type, empty results, key ordering preservation, numeric keys, genomic_coordinate keys with string data, and null key rejection
- **IO reader error checks (#178)**: Add `get_error_message().empty()` assertions after all range-for loops across BED (10 tests), GFF (8 tests), and BAM (22 tests) reader test suites to enforce the iterator contract

Closes #174, closes #178

## Test plan
- [x] All existing tests pass
- [x] New query_result tests cover previously untested template instantiations and edge cases
- [x] Error message checks catch any silent iteration failures across all IO readers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added query-result tests covering insertion order, empty results, numeric/genomic/interval keys, and null-key error handling.
  * Added post-iteration checks to ensure file readers report no error messages after consuming entries for BAM, BED, and GFF formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->