### PR TITLE
Cache EOF state in BED/GFF readers instead of peek-based has_next()

### DIFF
--- a/include/genogrove/io/bed_reader.hpp
+++ b/include/genogrove/io/bed_reader.hpp
@@ -109,7 +109,7 @@ namespace genogrove::io {
             : file_reader<bed_entry>(std::move(other)),
               bgzf_file(other.bgzf_file), line_num(other.line_num),
               error_message(std::move(other.error_message)),
-              options_(other.options_) {
+              options_(other.options_), at_eof_(other.at_eof_) {
             other.bgzf_file = nullptr;
         }
         bed_reader& operator=(bed_reader&& other) noexcept {
@@ -120,6 +120,7 @@ namespace genogrove::io {
                 line_num = other.line_num;
                 error_message = std::move(other.error_message);
                 options_ = other.options_;
+                at_eof_ = other.at_eof_;
                 other.bgzf_file = nullptr;
             }
             return *this;
@@ -136,6 +137,7 @@ namespace genogrove::io {
         size_t line_num;
         std::string error_message;
         bed_reader_options options_;
+        bool at_eof_{false};
 
         // Helper functions for parsing BED fields
         bool parse_score(bed_entry& entry, const std::string& score_str);

--- a/include/genogrove/io/bgzf_utils.hpp
+++ b/include/genogrove/io/bgzf_utils.hpp
@@ -25,9 +25,6 @@ namespace genogrove::io {
     /// Throws std::runtime_error on I/O error.
     std::optional<std::string> bgzf_next_data_line(BGZF* file, size_t& line_num);
 
-    /// Check whether more data is available in a BGZF stream (peek-based).
-    bool bgzf_has_next(BGZF* file);
-
 }
 
 #endif //GENOGROVE_IO_BGZF_UTILS_HPP

--- a/include/genogrove/io/gff_reader.hpp
+++ b/include/genogrove/io/gff_reader.hpp
@@ -97,7 +97,7 @@ namespace genogrove::io {
             : file_reader<gff_entry>(std::move(other)),
               bgzf_file(other.bgzf_file), line_num(other.line_num),
               error_message(std::move(other.error_message)),
-              options_(other.options_) {
+              options_(other.options_), at_eof_(other.at_eof_) {
             other.bgzf_file = nullptr;
         }
         gff_reader& operator=(gff_reader&& other) noexcept {
@@ -108,6 +108,7 @@ namespace genogrove::io {
                 line_num = other.line_num;
                 error_message = std::move(other.error_message);
                 options_ = other.options_;
+                at_eof_ = other.at_eof_;
                 other.bgzf_file = nullptr;
             }
             return *this;
@@ -124,6 +125,7 @@ namespace genogrove::io {
         size_t line_num;
         std::string error_message;
         gff_reader_options options_;
+        bool at_eof_{false};
 
         // Helper to parse attributes (handles both GFF3 and GTF formats)
         // Returns the detected format

--- a/src/io/bed_reader.cpp
+++ b/src/io/bed_reader.cpp
@@ -350,7 +350,7 @@ namespace genogrove::io {
             entry.blocks.reset();
 
             auto line_opt = bgzf_next_data_line(bgzf_file, line_num);
-            if (!line_opt) return false;  // EOF
+            if (!line_opt) { at_eof_ = true; return false; }
             const std::string& line = *line_opt;
 
             // parse the line
@@ -417,7 +417,7 @@ namespace genogrove::io {
     }
 
     bool bed_reader::has_next() {
-        return bgzf_has_next(bgzf_file);
+        return !at_eof_ && bgzf_file != nullptr;
     }
 
     std::string bed_reader::get_error_message() const {

--- a/src/io/bgzf_utils.cpp
+++ b/src/io/bgzf_utils.cpp
@@ -31,19 +31,4 @@ namespace genogrove::io {
         }
     }
 
-    bool bgzf_has_next(BGZF* file) {
-        if (!file) return false;
-
-        int64_t current_pos = bgzf_tell(file);
-        char peek_char;
-        int peek_result = bgzf_read(file, &peek_char, 1);
-
-        int64_t seek_result = bgzf_seek(file, current_pos, SEEK_SET);
-        if (seek_result < 0) {
-            return false;
-        }
-
-        return peek_result > 0;
-    }
-
 }

--- a/src/io/gff_reader.cpp
+++ b/src/io/gff_reader.cpp
@@ -269,7 +269,7 @@ namespace genogrove::io {
         while (true) {
             error_message.clear();
             auto line_opt = bgzf_next_data_line(bgzf_file, line_num);
-            if (!line_opt) return false;  // EOF
+            if (!line_opt) { at_eof_ = true; return false; }
             const std::string& line = *line_opt;
 
             // parse the line
@@ -369,7 +369,7 @@ namespace genogrove::io {
     }
 
     bool gff_reader::has_next() {
-        return bgzf_has_next(bgzf_file);
+        return !at_eof_ && bgzf_file != nullptr;
     }
 
     std::string gff_reader::get_error_message() const {


### PR DESCRIPTION
## Summary
### Fixed
- Replace `bgzf_has_next()` (3 syscalls per call: tell + read + seek) with a cached `at_eof_` flag in `bed_reader` and `gff_reader`, matching `bam_reader`'s existing pattern
- Remove now-unused `bgzf_has_next()` from `bgzf_utils`

Closes #166

## QC
- [x] I, as a human being, have checked each line of code in this pull request
- [ ] All existing BED reader tests pass across all platforms
- [ ] All existing GFF reader tests pass across all platforms
- [ ] BAM reader tests unaffected (no changes to bam_reader)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal state management for BED and GFF file readers by refactoring end-of-file detection logic.
  * Removed an internal utility function and consolidated file-reading state tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->