### PR TITLE
registry_test: document RegistryTest fixture reset scope

### DIFF
--- a/tests/data_type/registry_test.cpp
+++ b/tests/data_type/registry_test.cpp
@@ -68,6 +68,11 @@ struct hash<ExperimentInfo> {
 
 class RegistryTest : public ::testing::Test {
   protected:
+    // Resets only the default-tag registries used across most tests.
+    // Tests that intern into tagged registries (registry<T, Tag, ...>) must
+    // reset those singletons themselves — at both setup and teardown — since
+    // this fixture cannot enumerate user-added tags. See e.g.
+    // `TaggedRegistriesAreIndependentSingletons` for the pattern.
     void SetUp() override {
         gdt::registry<SampleInfo>::reset();
         gdt::registry<ExperimentInfo>::reset();


### PR DESCRIPTION
## Summary

- Adds a doc comment to the `RegistryTest::SetUp` method explaining what the fixture resets and what it does *not* reset. The fixture only knows about the four default-tag registries used across most tests (`<SampleInfo>`, `<ExperimentInfo>`, `<int>`, `<std::string>`); it cannot enumerate user-added tagged singletons (`registry<T, Tag, ...>`).
- Points readers at `TaggedRegistriesAreIndependentSingletons` as the canonical pattern for tests that need to reset tagged singletons at both setup and teardown.
- Pure documentation change. No behavior change, no signatures touched.

Closes #345.

## Why the lightweight fix

The two existing tagged-registry tests already do the right thing manually (in-test `R::reset()` pairs at top and bottom); the just-merged #401 also added per-fixture resets for its own `gene_registry`. The remaining risk is purely "future contributor adds a tagged-registry test inside the `RegistryTest` fixture and forgets the manual reset." A focused doc comment makes the convention discoverable at the point a contributor would look (the fixture body) without introducing a new abstraction.

## Test plan

- [ ] I, as a human being, have checked each line of code
- [x] All existing registry tests still pass (pure comment change)
- [x] Build with `BUILD_TESTING=ON` and run `ctest` — `RegistryTest.*` and `KeyPayloadRegistryTest.*` continue to pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added clarification documentation for test registry behavior and setup requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genogrove/genogrove/pull/403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
