### PR TITLE
Release v0.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.1] - 2026-05-18
+
 ### Refactored
 - **`gdt::registry<>` Rule of Five completeness**: adds an explicit `~registry() = default;` declaration next to the four already-deleted copy/move members so the type's intent is unambiguous to readers — singleton, non-copyable, non-movable, defaulted destructor. No behavior change; the compiler-generated destructor is identical to the explicit defaulted one. ([#358](https://github.com/genogrove/genogrove/issues/358), [#402](https://github.com/genogrove/genogrove/pull/402))
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(genogrove VERSION 0.24.0)
+project(genogrove VERSION 0.24.1)
 
 find_package(PkgConfig REQUIRED)
 find_package(ZLIB REQUIRED)


### PR DESCRIPTION
## Summary
### Changed
- Bump `project(genogrove VERSION 0.24.1)` in `CMakeLists.txt`
- Promote `## [Unreleased]` content to `## [0.24.1] - 2026-05-18` in `CHANGELOG.md`

## Release contents (already in `## [0.24.1]`)

### Added
- `gdt::registry<Key, Tag, Payload>` Payload template parameter + `intern(key, payload)` two-arg overload with first-write-wins semantics; conditional wire format preserves the historical layout when `Key == Payload`; `deserialize()` now rejects streams with duplicate keys (#400, #401)

### Refactored
- `gdt::registry<>` Rule of Five completeness — explicit `~registry() = default;` declaration alongside the four deleted copy/move members; no behavior change (#358, #402)

## Follow-ups after merge
- Tag `v0.24.1` on the merge commit and push the tag (`git tag -a v0.24.1 -m "Release v0.24.1"`)
- Cut GitHub release with the same content
- Open docs version-bump issue in `genogrove/docs` (`conf.py` + README badge)
- Bump atroplex `GIT_TAG v0.24.1` in its `CMakeLists.txt`

## QC
- [ ] I, as a human being, have checked each line of code in this pull request
- [x] CI green on all platforms
- [x] `[Unreleased]` is empty and `[0.24.1] - 2026-05-18` heading is in place
- [x] `CMakeLists.txt` reports `VERSION 0.24.1`
