### PR TITLE
bam_reader: simplify parse_alignment, dedupe cigar predicate (#351, #352)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Refactored
+- **`bam_reader` internals**: `parse_alignment` now returns `void` (the previous `bool` return was always `true` and discarded at the call site; truncation still propagates via `throw`), and `compute_interval` now takes the already-parsed `cigar_string&` and reuses `cigar_element::consumes_reference()` instead of an inline CIGAR-op predicate — single source of truth for the reference-consuming op set. No behavior change: `parse_cigar` already filtered ops with code > 8, and the old inline predicate matched the same ops (M/D/N/=/X) the typed predicate now matches. ([#351](https://github.com/genogrove/genogrove/issues/351), [#352](https://github.com/genogrove/genogrove/issues/352), [#405](https://github.com/genogrove/genogrove/pull/405))
+
 ## [0.24.1] - 2026-05-18
 
 ### Refactored

--- a/include/genogrove/io/bam_reader.hpp
+++ b/include/genogrove/io/bam_reader.hpp
@@ -429,10 +429,10 @@ namespace genogrove::io {
         bool should_skip(const bam1_t* b) const;
 
         /// Parse alignment record into sam_entry
-        bool parse_alignment(const bam1_t* b, sam_entry& entry);
+        void parse_alignment(const bam1_t* b, sam_entry& entry);
 
         /// Compute reference interval from position and CIGAR
-        std::pair<size_t, size_t> compute_interval(int64_t pos, const bam1_t* b) const;
+        std::pair<size_t, size_t> compute_interval(int64_t pos, const cigar_string& cigar) const;
 
         /// Parse CIGAR string from bam1_t
         cigar_string parse_cigar(const bam1_t* b) const;

--- a/src/io/bam_reader.cpp
+++ b/src/io/bam_reader.cpp
@@ -177,7 +177,7 @@ namespace genogrove::io {
         return false;
     }
 
-    bool bam_reader::parse_alignment(const bam1_t* b, sam_entry& entry) {
+    void bam_reader::parse_alignment(const bam1_t* b, sam_entry& entry) {
         const bam1_core_t& c = b->core;
 
         // Query name (QNAME)
@@ -205,7 +205,7 @@ namespace genogrove::io {
             entry.start = 0;
             entry.end = 0;
         } else {
-            auto [iv_start, iv_end] = compute_interval(c.pos, b);
+            auto [iv_start, iv_end] = compute_interval(c.pos, entry.cigar);
             entry.start = iv_start;
             entry.end = iv_end;
         }
@@ -254,11 +254,9 @@ namespace genogrove::io {
             error_message_ = "Truncated auxiliary data at record " + std::to_string(record_num_);
             throw std::runtime_error(error_message_);
         }
-
-        return true;
     }
 
-    std::pair<size_t, size_t> bam_reader::compute_interval(int64_t pos, const bam1_t* b) const {
+    std::pair<size_t, size_t> bam_reader::compute_interval(int64_t pos, const cigar_string& cigar) const {
         // Calculate reference length consumed by CIGAR.
         // Pure soft-clip (e.g. "100S") and hard-clip-only secondary records
         // consume zero reference bases and return a zero-length half-open
@@ -266,18 +264,10 @@ namespace genogrove::io {
         // `sam_entry::consumes_reference()` and filter as appropriate;
         // converting to a closed `gdt::interval(start, end - 1)` is only
         // valid when `start < end`.
-        uint32_t* cigar = bam_get_cigar(b);
-        uint32_t n_cigar = b->core.n_cigar;
-
         int64_t ref_len = 0;
-        for (uint32_t i = 0; i < n_cigar; ++i) {
-            int op = bam_cigar_op(cigar[i]);
-            int len = bam_cigar_oplen(cigar[i]);
-
-            // Operations that consume reference bases: M, D, N, =, X
-            if (op == BAM_CMATCH || op == BAM_CDEL || op == BAM_CREF_SKIP ||
-                op == BAM_CEQUAL || op == BAM_CDIFF) {
-                ref_len += len;
+        for (const auto& e : cigar) {
+            if (e.consumes_reference()) {
+                ref_len += e.length;
             }
         }
 


### PR DESCRIPTION
## Summary

Two small `bam_reader` cleanups bundled because they touch the same function pair and are individually trivial.

- **#351** — `parse_alignment` returned `bool` but never returned `false`. The sole call site already discarded the value. Changed the return type to `void`; truncation still propagates via `throw`.
- **#352** — `compute_interval` walked the raw htslib CIGAR array with an inline op predicate (`BAM_CMATCH || BAM_CDEL || BAM_CREF_SKIP || BAM_CEQUAL || BAM_CDIFF`), duplicating `cigar_element::consumes_reference()`. Now takes a parsed `cigar_string&` and reuses the typed predicate — single source of truth.

The parsed `entry.cigar` is already populated immediately before the `compute_interval` call, so threading it through costs nothing.

## Why bundled

Both findings come from the same `/cpp-audit` pass on 2026-05-16, both touch `parse_alignment` / `compute_interval`, and #352's fix mechanically rebuilds the call site that #351 simplifies. Splitting would mean two PRs that re-touch the same five lines.

## Behavioral equivalence

`parse_cigar` already drops CIGAR ops with code `> 8`, and the old inline predicate only matched ops 0/2/3/7/8 — so invalid ops contributed zero reference length under either form. No semantic change.

Closes #351, closes #352.

## Test plan

- [x] I, as a human being, have checked each line of code
- [x] `cmake --build build && ctest --output-on-failure` passes (in particular `bamfile-test`)
- [x] Spot-check: BAM file with pure soft-clip record still yields `start == end == POS`
- [x] Spot-check: BAM file with `M`/`D`/`N`/`=`/`X` mix yields the same `end` as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to BAM file parsing logic to enhance code modularity and maintainability. No user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genogrove/genogrove/pull/405?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
