### PR TITLE
docs: clarify four cpp-audit comment/docstring gaps (#329, #380, #383, #384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`numeric` default-constructor docstring**: adds a `@warning` that the `INT_MIN` sentinel is in-band — a default-constructed `numeric` is indistinguishable from (and `overlaps()`) a `numeric` holding the real value `INT_MIN`. Documents an existing behavior; no code change. ([#383](https://github.com/genogrove/genogrove/issues/383), [#412](https://github.com/genogrove/genogrove/pull/412))
+
 ## [0.24.2] - 2026-05-19
 
 ### Refactored

--- a/include/genogrove/data_type/numeric.hpp
+++ b/include/genogrove/data_type/numeric.hpp
@@ -61,6 +61,11 @@ namespace genogrove::data_type {
              * Uses the minimum representable value as a sentinel so that
              * max-based aggregation in internal nodes works correctly:
              * any real value will be greater than the default.
+             *
+             * @warning A default-constructed numeric and a numeric holding the
+             *          real value INT_MIN are indistinguishable, so `numeric{}`
+             *          compares equal to (and overlaps) `numeric{INT_MIN}`.
+             *          Don't rely on the default being distinct from stored data.
              */
             constexpr numeric() : value(std::numeric_limits<int>::min()) {}
 

--- a/include/genogrove/structure/grove/grove_query.ipp
+++ b/include/genogrove/structure/grove/grove_query.ipp
@@ -46,9 +46,22 @@ private:
      * @param current The node to start searching from
      * @param query The query key to search for
      * @param result Reference to query_result where matching keys are accumulated
-     * @note Recurses into child nodes (bounded by tree depth O(log n))
-     * @note Walks the leaf sibling chain iteratively (unbounded, avoids stack overflow)
-     * @note Optimized for interval types with early termination when no overlap is possible
+     *
+     * Two phases:
+     * - **Internal descent (recursive).** At each internal node, picks the
+     *   single first child whose separator may overlap and recurses into it —
+     *   one child per level, so the recursion depth is the tree height
+     *   O(log n). It does NOT fan out across multiple children.
+     * - **Leaf walk (iterative).** Once at a leaf, walks the leaf sibling
+     *   chain via next pointers in a loop (unbounded length, so iterative to
+     *   avoid stack overflow), pruning for interval keys only when a leaf's
+     *   `first_key.start > query.end`.
+     *
+     * @note Correctness depends on two invariants: internal separators must
+     *       reflect `calc_subtree_range()` (so the single-child descent never
+     *       skips a subtree that contains a match), and the leaf chain must be
+     *       globally sorted by start (so the `first_key.start` prune is sound).
+     *       Both must hold after every split / rebalance.
      */
     void search_iter(node<key_type, data_type>* current, const key_type& query,
         gdt::query_result<key_type, data_type>& result) {

--- a/src/io/gff_reader.cpp
+++ b/src/io/gff_reader.cpp
@@ -225,6 +225,10 @@ namespace genogrove::io {
         const char* begin = score_s.c_str();
         char* end_ptr = nullptr;
         errno = 0;
+        // Initialized once on first use (thread-safe per C++11 static-init rules)
+        // and intentionally never freed: the locale must outlive every parse_score
+        // call, so it lives for the program's lifetime. freelocale() is deliberately
+        // omitted — this is a one-off allocation, not a leak that grows.
         static locale_t c_locale = []() {
             locale_t loc = newlocale(LC_ALL_MASK, "C", nullptr);
             if (!loc) throw std::runtime_error("newlocale failed");

--- a/tests/cli/intersect-e2e-test.cpp
+++ b/tests/cli/intersect-e2e-test.cpp
@@ -40,6 +40,9 @@ CmdResult run_command(const std::string& cmd) {
     std::array<char, 4096> buffer;
     result.output.clear();
 
+    // popen/pclose are POSIX, not ISO C++. This e2e test targets the
+    // Linux/macOS CI matrix only; an MSVC build would need _popen/_pclose
+    // (and the WIFEXITED decoding below is already guarded for _WIN32).
     FILE* pipe = popen(full_cmd.c_str(), "r");
     if(!pipe) {
         result.exit_code = -1;

--- a/tests/data_type/numeric_test.cpp
+++ b/tests/data_type/numeric_test.cpp
@@ -293,7 +293,9 @@ TEST(numericTest, intMinMaxComparison) {
 }
 
 TEST(numericTest, defaultOverlapsWithIntMin) {
-    // Default value is INT_MIN
+    // A default-constructed numeric holds INT_MIN, so it is indistinguishable
+    // from a numeric holding the real value INT_MIN (see numeric's default
+    // ctor). This asserts that accepted behavior, not a desirable one.
     gdt::numeric def;
     gdt::numeric nmin(std::numeric_limits<int>::min());
 


### PR DESCRIPTION
## Summary

A comment-only pass over four `docs`-labeled `/cpp-audit` findings. No code, no behavior change — each adds or rewrites an explanatory comment/docstring.

### Changed

- **#383** — `numeric`'s default ctor sets the value to `INT_MIN` as a sentinel (identity for the `max`-based aggregate). The docstring explained the *purpose* but not the *trap*: `INT_MIN` is an in-band value, so a default-constructed `numeric` is byte-identical to — and `overlaps()` — a `numeric` holding the legitimate value `INT_MIN`. Added a `@warning` saying so; `numeric_test.defaultOverlapsWithIntMin` now notes it asserts accepted (not desirable) behavior. Documentation only — the sentinel design stands (it was a deliberate choice over `std::optional`).
- **#329** — the `search_iter` docstring (and CLAUDE.md) implied the search is fully iterative. It isn't: the *internal-node descent* is recursive (one child per level, depth O(log n)); only the *leaf-chain walk* is iterative. Rewrote the docstring to describe both phases accurately and to spell out the two invariants correctness depends on — separators reflecting `calc_subtree_range()`, and the leaf chain being globally sorted by start. (CLAUDE.md is maintained separately by the author and is intentionally left untouched here.)
- **#384** — `gff_reader::parse_score`'s static `locale_t` is initialized once and never freed. Added a comment: it's a deliberate program-lifetime allocation (the locale must outlive every `parse_score` call), thread-safe per C++11 static-init rules — not a growing leak.
- **#380** — `intersect-e2e-test.cpp`'s `run_command` uses `popen`/`pclose`, which are POSIX, not ISO C++. Added a comment noting the e2e test targets the Linux/macOS CI matrix only (MSVC would need `_popen`/`_pclose`; the `WIFEXITED` decoding is already `_WIN32`-guarded).

### Why bundled

All four are `docs`-labeled cpp-audit findings — pure comment/docstring clarifications. One review, one CHANGELOG entry.

### Note on #379

The fifth open `docs` issue (#379, `get_current_line()` counter semantics) is **not** included. It looks like a doc fix but isn't: `bed_reader` / `gff_reader` count physical lines (incl. comments) while `bam_reader::get_current_line()` returns a *record* count — a genuine cross-reader contract inconsistency, and #379 itself cross-references the open bam-counter bug #328. Documenting `file_reader_base::get_current_line()` as one definite thing would contradict `bam_reader`. It needs a policy decision alongside #328, not a paper-over comment — so it's left for separate treatment.

Closes #329, closes #380, closes #383, closes #384.

## Test plan

- [x] I, as a human being, have checked each line of code
- [x] `cmake --build build -DBUILD_TESTING=ON && ctest --output-on-failure` passes (comment-only, so this is a sanity check that nothing failed to compile)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation for the numeric data type's default constructor, clarifying behavior and potential edge cases with stored values.
  * Enhanced algorithm documentation for query search functionality with detailed descriptions of algorithm phases and invariant requirements.
  * Improved code comments throughout the codebase, including clarifications about resource lifecycle management and platform-specific implementation details, enhancing code maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genogrove/genogrove/pull/412?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
