### PR TITLE
io: document get_current_line() contract, fix bam doc + counter tests (#328, #379)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`get_current_line()` contract documentation**: `bam_reader::get_current_line()`'s docstring said "Number of records read so far", implying records *yielded* by `read_next()` — but it counts every record *consumed* from the file, including records dropped by `should_skip()`. Corrected the docstring to match (behavior is unchanged: counting skipped records is what makes the "record N" in error messages point at the real file position). Also added the previously-absent docstring on `file_reader_base::get_current_line()` defining the contract — a 1-based input-consumed position, reader-specific unit (physical line for BED/GFF including comments/blanks, record index for BAM including filtered records), reflecting input consumed rather than entries yielded. ([#328](https://github.com/genogrove/genogrove/issues/328), [#379](https://github.com/genogrove/genogrove/issues/379), [#413](https://github.com/genogrove/genogrove/pull/413))
+
 ### Changed
 - **`numeric` default-constructor docstring**: adds a `@warning` that the `INT_MIN` sentinel is in-band — a default-constructed `numeric` is indistinguishable from (and `overlaps()`) a `numeric` holding the real value `INT_MIN`. Documents an existing behavior; no code change. ([#383](https://github.com/genogrove/genogrove/issues/383), [#412](https://github.com/genogrove/genogrove/pull/412))
 

--- a/include/genogrove/io/bam_reader.hpp
+++ b/include/genogrove/io/bam_reader.hpp
@@ -384,7 +384,12 @@ namespace genogrove::io {
         /**
          * @brief Get the current record number (1-based).
          *
-         * @return Number of records read so far
+         * Counts every record consumed from the file, including records
+         * dropped by the configured filters (see bam_reader_options) — it is
+         * the file position, not the count of records returned by read_next().
+         * If an unmapped record is skipped, the counter still advances past it.
+         *
+         * @return Index of the most recently consumed record (0 before the first read)
          */
         size_t get_current_line() const override;
 

--- a/include/genogrove/io/file_reader.hpp
+++ b/include/genogrove/io/file_reader.hpp
@@ -18,6 +18,14 @@ namespace genogrove::io {
         /// Returns the error message from the most recent read_next() call.
         /// Cleared at the start of each read_next(); empty if the last read succeeded.
         virtual std::string get_error_message() const = 0;
+        /// Returns the 1-based position the reader has consumed up to in its input.
+        /// The unit is reader-specific: the physical line number for the text
+        /// readers (BED/GFF — comment and blank lines are counted), or the record
+        /// index for the BAM reader (records dropped by filters are counted).
+        /// In all cases it reflects input *consumed*, not entries *yielded* by
+        /// read_next() — a skipped comment line or a filtered-out record still
+        /// advances it. Zero before the first read_next(). Intended for error
+        /// messages and progress reporting, not for counting returned entries.
         virtual size_t get_current_line() const = 0;
         virtual ~file_reader_base() = default;
     };

--- a/tests/io/bamfile-test.cpp
+++ b/tests/io/bamfile-test.cpp
@@ -569,16 +569,29 @@ TEST_F(BamReaderTest, HasNextFunctionality) {
 }
 
 TEST_F(BamReaderTest, LineCounter) {
+    // get_current_line() counts every record consumed from the file,
+    // including records dropped by filters — it is the file position, not
+    // the number of records read_next() returned. test.sam's 5th record
+    // (read004) is unmapped, so under the default skip_unmapped option it
+    // is consumed-and-skipped: the 5th successful read_next() lands the
+    // counter on 6, not 5.
     gio::bam_reader reader(sam_path);
     gio::sam_entry entry;
 
     EXPECT_EQ(reader.get_current_line(), 0);
 
-    reader.read_next(entry);
+    reader.read_next(entry);                       // read001/99
     EXPECT_EQ(reader.get_current_line(), 1);
 
-    reader.read_next(entry);
+    reader.read_next(entry);                       // read001/147
     EXPECT_EQ(reader.get_current_line(), 2);
+
+    reader.read_next(entry);                       // read002
+    reader.read_next(entry);                       // read003
+    EXPECT_EQ(reader.get_current_line(), 4);
+
+    reader.read_next(entry);                       // read004 skipped, read005 yielded
+    EXPECT_EQ(reader.get_current_line(), 6);
 }
 
 // ==========================================

--- a/tests/io/bedfile-test.cpp
+++ b/tests/io/bedfile-test.cpp
@@ -210,6 +210,10 @@ TEST_F(bedfileTest, hasNextFunctionality) {
 }
 
 TEST_F(bedfileTest, lineCounter) {
+    // get_current_line() reports the 1-based physical line number, counting
+    // comment and blank lines. test_bed3.bed has neither, so here the line
+    // number coincides with the record index. The comment-counting case is
+    // covered by gfffileTest.lineCounter.
     gio::bed_reader reader(bed3_path);
     gio::bed_entry entry;
 

--- a/tests/io/gfffile-test.cpp
+++ b/tests/io/gfffile-test.cpp
@@ -204,6 +204,10 @@ TEST_F(gfffileTest, hasNextFunctionality) {
 }
 
 TEST_F(gfffileTest, lineCounter) {
+    // get_current_line() reports the 1-based physical line number, counting
+    // comment and blank lines even though they are not yielded as records.
+    // test_gff3.gff line 1 is the "##gff-version 3" directive, so the first
+    // data record reports line 2.
     gio::gff_reader reader(gff3_path);
     gio::gff_entry entry;
 


### PR DESCRIPTION
## Summary

`file_reader_base::get_current_line()` had no docstring at all, and the three readers each count a *different unit* — which left the contract undefined and the `bam_reader` override doc outright wrong. This documents the contract and fixes the fallout.

### Fixed

- **#328** — `bam_reader::get_current_line()`'s docstring said "Number of records read so far", which implies *records yielded by `read_next()`*. It actually returns `record_num_`, which increments on **every** record pulled from the file, including records dropped by `should_skip()`. Corrected the docstring to describe the real semantics. **Behavior is intentionally unchanged**: counting skipped records is what makes the "record N" in `bam_reader`'s I/O-error and truncation messages point at the true file position. (Renaming the virtual to `get_records_seen()`, the issue's other suggestion, would be a gratuitous API break across the base class + three readers + every caller — the doc was the defect, not the behavior.)

### Changed

- **`file_reader_base::get_current_line()`** — added a docstring defining the contract: it is the 1-based position the reader has *consumed up to*. The unit is reader-specific — physical line number for the text readers (BED/GFF, comment and blank lines counted), record index for BAM (filter-dropped records counted) — but in all cases it reflects input *consumed*, not entries *yielded*. Zero before the first `read_next()`.

### Tests (#379)

The three `lineCounter` tests each only exercised the happy path where the counter happens to equal the record index, which is what made them *look* like they had different contracts:

- `bedfileTest.lineCounter` — `test_bed3.bed` has no comment/blank lines, so line number == record index. Added a comment saying so and pointing at the GFF test for the comment case.
- `gfffileTest.lineCounter` — `test_gff3.gff` line 1 is `##gff-version 3`, so the first record reports line 2. Added a comment making that explicit.
- `BamReaderTest.LineCounter` — **extended** to read through `test.sam`'s 5th record (`read004`, unmapped → skipped under the default `skip_unmapped`) and assert the counter lands on **6** after the 5th successful `read_next()`, not 5. This pins the counts-skipped-records semantic that #328 documents.

### Why bundled

#379 explicitly cross-references #328 — they are the same contract. Documenting `get_current_line()` (#379) is only meaningful once the `bam_reader` doc that contradicts it (#328) is fixed, and the test that proves the BAM behavior is the same edit.

### Behavior

No behavior change anywhere — docstrings plus test assertions only.

Closes #328, closes #379.

## Test plan

- [x] I, as a human being, have checked each line of code
- [x] `cmake --build build -DBUILD_TESTING=ON && ctest --output-on-failure` passes — in particular the extended `BamReaderTest.LineCounter` (the `0 → 1 → 2 → 4 → 6` sequence across the `read004` skip) and `bedfileTest.lineCounter` / `gfffileTest.lineCounter`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified file reader line counter behavior: counters track all consumed records from input (including filtered or skipped entries), not just yielded entries
  * Added explanatory notes to tests documenting line number reporting behavior across different file formats

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genogrove/genogrove/pull/413?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
