### PR TITLE
io: explicit special members on reader bases and kstring_guard (#326, #375)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Refactored
+- **Explicit special members on the reader bases and `kstring_guard`**: `file_reader_base` and `file_reader<T>` never declared their own move members — `file_reader_base`'s virtual destructor suppressed implicit moves, so a derived reader's move silently fell through to the base's copy-assignment. Both bases now explicitly default-construct, delete copy (a polymorphic-base copy slices), and default move; `file_reader<T>` also defaults its destructor. `kstring_guard` gains explicit `= delete`d move members (already implicitly unavailable). No behavior change — the bases are stateless, so defaulted moves are identical to the prior copy path. ([#326](https://github.com/genogrove/genogrove/issues/326), [#375](https://github.com/genogrove/genogrove/issues/375), [#414](https://github.com/genogrove/genogrove/pull/414))
+
 ### Fixed
 - **`get_current_line()` contract documentation**: `bam_reader::get_current_line()`'s docstring said "Number of records read so far", implying records *yielded* by `read_next()` — but it counts every record *consumed* from the file, including records dropped by `should_skip()`. Corrected the docstring to match (behavior is unchanged: counting skipped records is what makes the "record N" in error messages point at the real file position). Also added the previously-absent docstring on `file_reader_base::get_current_line()` defining the contract — a 1-based input-consumed position, reader-specific unit (physical line for BED/GFF including comments/blanks, record index for BAM including filtered records), reflecting input consumed rather than entries yielded. ([#328](https://github.com/genogrove/genogrove/issues/328), [#379](https://github.com/genogrove/genogrove/issues/379), [#413](https://github.com/genogrove/genogrove/pull/413))
 

--- a/include/genogrove/io/file_reader.hpp
+++ b/include/genogrove/io/file_reader.hpp
@@ -27,7 +27,16 @@ namespace genogrove::io {
         /// advances it. Zero before the first read_next(). Intended for error
         /// messages and progress reporting, not for counting returned entries.
         virtual size_t get_current_line() const = 0;
+
+        file_reader_base() = default;
         virtual ~file_reader_base() = default;
+        // Polymorphic base: copying would slice. Move is explicitly defaulted
+        // so a derived reader's move moves *through* the base subobject rather
+        // than silently falling back to the base's copy-assignment.
+        file_reader_base(const file_reader_base&) = delete;
+        file_reader_base& operator=(const file_reader_base&) = delete;
+        file_reader_base(file_reader_base&&) = default;
+        file_reader_base& operator=(file_reader_base&&) = default;
     };
 
     // Forward declaration
@@ -141,6 +150,13 @@ namespace genogrove::io {
     class file_reader : public file_reader_base {
     public:
         using iterator = file_reader_iterator<EntryType>;
+
+        file_reader() = default;
+        ~file_reader() override = default;
+        file_reader(const file_reader&) = delete;
+        file_reader& operator=(const file_reader&) = delete;
+        file_reader(file_reader&&) = default;
+        file_reader& operator=(file_reader&&) = default;
 
         virtual bool read_next(EntryType& entry) = 0;
 

--- a/include/genogrove/io/kstring_guard.hpp
+++ b/include/genogrove/io/kstring_guard.hpp
@@ -19,6 +19,10 @@ struct kstring_guard {
 
     kstring_guard(const kstring_guard&) = delete;
     kstring_guard& operator=(const kstring_guard&) = delete;
+    // Already implicitly unavailable (the user-declared destructor suppresses
+    // implicit move generation); declared explicitly to state the intent.
+    kstring_guard(kstring_guard&&) = delete;
+    kstring_guard& operator=(kstring_guard&&) = delete;
 };
 
 }


### PR DESCRIPTION
## Summary

Two `/cpp-audit` Rule-of-Five findings — making implicit/fragile special-member behavior explicit on RAII / polymorphic types. No behavior change.

### Refactored

- **#326** `[High]` — every concrete reader (`bed_reader` / `gff_reader` / `bam_reader` / `fasta_reader`) already declares a full Rule of Five, and their move ctor/assign call through `file_reader<EntryType>`'s special members. But **neither base** — `file_reader_base` nor `file_reader<T>` — declared its own move members: `file_reader_base`'s user-declared virtual destructor suppresses implicit move generation, so a move through the base subobject silently fell back to the base's *copy*-assignment. Harmless today because both bases are stateless, but fragile — any future base state (a logger, a stats counter) would be copied, not moved, with no diagnostic. Both bases now explicitly: default-construct, **delete copy** (a polymorphic base copy would slice), and **default move**; `file_reader<T>` also defaults its destructor. The four concrete readers already declare their special members explicitly, so they need no change — the gap was purely in the bases.
- **#375** `[Low]` — `kstring_guard` (an htslib `kstring_t` RAII guard) declared deleted copy ops but not move ops. The moves are already implicitly unavailable — the user-declared destructor suppresses them — so this is intent-only: explicit `= delete` on the move ctor/assign states the non-movable Rule of Five outright instead of leaving it to the suppression rules.

### Why bundled

Same topic — making special-member intent explicit on RAII / polymorphic types flagged by the same cpp-audit pass. One review.

### Behavior

No behavior change. `file_reader_base` / `file_reader<T>` are stateless, so defaulting their move members produces identical results to the previous (copy-based) path; `kstring_guard`'s moves were already unavailable. The four concrete readers are untouched.

Closes #326, closes #375.

## Test plan

- [x] I, as a human being, have checked each line of code
- [x] `cmake --build build -DBUILD_TESTING=ON && ctest --output-on-failure` passes — in particular the reader move-semantics tests (move ctor / move assign for bed/gff/bam/fasta readers)
