### PR TITLE
test: address cpp-audit test-coverage findings (#344, #350, #377, #378)

### DIFF
--- a/tests/structure/grove_remove_test.cpp
+++ b/tests/structure/grove_remove_test.cpp
@@ -175,6 +175,30 @@ TEST(GroveRemoveTest, RemoveLastChildLeaf) {
     }
 }
 
+TEST(GroveRemoveTest, RemoveFirstChildLeaf) {
+    // Asymmetric mirror of RemoveLastChildLeaf: emptying the LEFTMOST leaf.
+    // With no left sibling to borrow from or merge into, the underflowing
+    // leaf must merge into its RIGHT sibling — exercises the dedicated
+    // branch in grove_remove.ipp that RemoveLastChildLeaf never reaches.
+    gst::grove<gdt::interval, int> grove(3);
+    auto keys = insert_intervals(grove, "chr1", 5);
+
+    // Walk to the leftmost leaf.
+    auto* root = grove.get_root_nodes().at("chr1");
+    auto* leaf = root;
+    while (!leaf->get_is_leaf()) leaf = leaf->get_child(0);
+
+    // Remove every key in it — triggers the "empty first child" merge path.
+    auto leaf_keys = leaf->get_keys();  // copy since we mutate
+    for (auto* k : leaf_keys) {
+        EXPECT_TRUE(grove.remove_key("chr1", k));
+        if (auto root_it = grove.get_root_nodes().find("chr1");
+            root_it != grove.get_root_nodes().end()) {
+            validate_grove_index(root_it->second, 3);
+        }
+    }
+}
+
 // =============================================================================
 // Rebalancing Tests — use order=3 (max 2 keys/node, min_keys=1)
 // =============================================================================

--- a/tests/structure/precondition_test.cpp
+++ b/tests/structure/precondition_test.cpp
@@ -15,6 +15,7 @@
 #include <genogrove/data_type/query_result.hpp>
 #include <genogrove/structure/grove/grove.hpp>
 #include <genogrove/structure/grove/node.hpp>
+#include <genogrove/structure/grove/zlib_streambuf.hpp>
 
 namespace gst = genogrove::structure;
 namespace gdt = genogrove::data_type;
@@ -153,6 +154,24 @@ TEST(ruleOfFiveTest, groveMoveTransfersOwnership) {
 
     // g1 should be empty (moved-from)
     EXPECT_EQ(g1.get_root_nodes().size(), 0);
+}
+
+TEST(ruleOfFiveTest, zlibStreambufsAreNonCopyableNonMovable) {
+    // The zlib streambufs own a raw z_stream and are copy AND move deleted.
+    // These static_asserts pin all four members so a future refactor cannot
+    // silently re-enable a move (which would double-free the z_stream).
+    using deflate_buf = gst::detail::deflate_streambuf;
+    using inflate_buf = gst::detail::inflate_streambuf;
+
+    static_assert(!std::is_copy_constructible_v<deflate_buf>);
+    static_assert(!std::is_copy_assignable_v<deflate_buf>);
+    static_assert(!std::is_move_constructible_v<deflate_buf>);
+    static_assert(!std::is_move_assignable_v<deflate_buf>);
+
+    static_assert(!std::is_copy_constructible_v<inflate_buf>);
+    static_assert(!std::is_copy_assignable_v<inflate_buf>);
+    static_assert(!std::is_move_constructible_v<inflate_buf>);
+    static_assert(!std::is_move_assignable_v<inflate_buf>);
 }
 
 // =============================================================================

--- a/tests/utility/ranges-test.cpp
+++ b/tests/utility/ranges-test.cpp
@@ -6,7 +6,7 @@
 #include <gtest/gtest.h>
 #include <genogrove/utility/ranges.hpp>
 
-TEST(ranges, empty)
+TEST(ranges, basicLookup)
 {
     // create a range (unordered map)
     std::unordered_map<std::string, uint8_t> map = {{"a", 1}, {"b", 2},{"c", 3}};

--- a/tests/utility/tokenizer-test.cpp
+++ b/tests/utility/tokenizer-test.cpp
@@ -116,3 +116,73 @@ TEST(tokenizer, custom_delimiter_semicolon) {
     EXPECT_EQ(*f1, "gene_id \"ABC\"");
     EXPECT_EQ(*f2, " transcript_id \"XYZ\"");
 }
+
+TEST(tokenizer, gtf_field_simple_key_value) {
+    std::string_view line = "gene_id \"ABC\"; transcript_id \"XYZ\"";
+    size_t pos = 0;
+
+    auto f1 = ggu::next_gtf_field(line, pos);
+    auto f2 = ggu::next_gtf_field(line, pos);
+    auto f3 = ggu::next_gtf_field(line, pos);
+
+    ASSERT_TRUE(f1.has_value());
+    ASSERT_TRUE(f2.has_value());
+    EXPECT_FALSE(f3.has_value());
+
+    EXPECT_EQ(*f1, "gene_id \"ABC\"");
+    EXPECT_EQ(*f2, " transcript_id \"XYZ\"");
+}
+
+TEST(tokenizer, gtf_field_quoted_semicolons) {
+    // Semicolons inside double-quoted values must not split the field.
+    std::string_view line = "gene_id \"A;B;C\"; transcript_id \"X\"";
+    size_t pos = 0;
+
+    auto f1 = ggu::next_gtf_field(line, pos);
+    auto f2 = ggu::next_gtf_field(line, pos);
+    auto f3 = ggu::next_gtf_field(line, pos);
+
+    ASSERT_TRUE(f1.has_value());
+    ASSERT_TRUE(f2.has_value());
+    EXPECT_FALSE(f3.has_value());
+
+    EXPECT_EQ(*f1, "gene_id \"A;B;C\"");
+    EXPECT_EQ(*f2, " transcript_id \"X\"");
+}
+
+TEST(tokenizer, gtf_field_unbalanced_quote) {
+    // An unterminated quote leaves the tokenizer "in quotes" to end-of-line,
+    // so the whole remainder is returned as a single field (no crash).
+    std::string_view line = "gene_id \"unterminated";
+    size_t pos = 0;
+
+    auto f1 = ggu::next_gtf_field(line, pos);
+    auto f2 = ggu::next_gtf_field(line, pos);
+
+    ASSERT_TRUE(f1.has_value());
+    EXPECT_FALSE(f2.has_value());
+
+    EXPECT_EQ(*f1, "gene_id \"unterminated");
+}
+
+TEST(tokenizer, gtf_field_empty_string) {
+    std::string_view line = "";
+    size_t pos = 0;
+
+    EXPECT_FALSE(ggu::next_gtf_field(line, pos).has_value());
+}
+
+TEST(tokenizer, gtf_field_trailing_semicolon) {
+    // GTF attribute lines end with a trailing ';' — it must not yield an
+    // extra empty field.
+    std::string_view line = "gene_id \"ABC\";";
+    size_t pos = 0;
+
+    auto f1 = ggu::next_gtf_field(line, pos);
+    auto f2 = ggu::next_gtf_field(line, pos);
+
+    ASSERT_TRUE(f1.has_value());
+    EXPECT_FALSE(f2.has_value());
+
+    EXPECT_EQ(*f1, "gene_id \"ABC\"");
+}


### PR DESCRIPTION
## Summary

Bundles four `test`-labeled findings from the 2026-05-16 `/cpp-audit` run. All changes are test-only — no production code or public API is touched.

- **#378** — `tokenizer-test.cpp`: `next_gtf_field` (the GTF-aware semicolon tokenizer) had zero direct coverage. Adds tests for simple key-value pairs, semicolons inside quoted values, unbalanced quotes, empty input, and the canonical trailing-semicolon case.
- **#377** — `ranges-test.cpp`: `TEST(ranges, empty)` actually verifies populated-map lookups, not emptiness. Renamed to `basicLookup`.
- **#350** — `precondition_test.cpp`: adds `static_assert`s pinning `detail::deflate_streambuf` / `detail::inflate_streambuf` as both copy- and move-deleted, so a future refactor can't silently re-enable a move.
- **#344** — `grove_remove_test.cpp`: adds `RemoveFirstChildLeaf`, the asymmetric mirror of the existing `RemoveLastChildLeaf` — emptying the leftmost leaf forces a merge into the right sibling.

Note: #343 (CLI `idx` stub) was also in this audit batch but is intentionally excluded — see the issue for context.

## Test plan

- [x] I, as a human being, have checked each line of code
- [x] `tokenizer-test` passes, including the five new `gtf_field_*` cases
- [x] `ranges-test` passes under the renamed `basicLookup`
- [x] `precondition_test` compiles (the new `static_assert`s are the assertion) and passes
- [x] `grove_remove_test` passes, including `RemoveFirstChildLeaf`

Closes #344
Closes #350
Closes #377
Closes #378

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
- Added test coverage for grove removal and rebalancing behavior
- Added test coverage validating streambuf immutability constraints
- Expanded tokenizer test suite with GTF field parsing coverage, including quote handling and edge cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genogrove/genogrove/pull/416?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
