### PR TITLE
Release v0.24.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.3] - 2026-05-21
+
 ### Added
 - **`intersect` searches a prebuilt index (`-i`)**: `intersect` now accepts a prebuilt `.gg` index via `-i/--indexfile` and searches it directly, so the source BED file is not needed. `-t` (build the grove from a target BED) and `-i` are alternatives — at least one is required. ([#422](https://github.com/genogrove/genogrove/issues/422), [#423](https://github.com/genogrove/genogrove/pull/423))
 - **`idx` CLI subcommand**: `genogrove idx <file.bed>` reads a BED file, builds an interval grove, and serializes it to a zlib-compressed `.gg` index file (default `<input>.gg`, or `-o <path>`) — previously the subcommand threw `"not yet implemented"`. Honors `-k` (tree order), `-s` (sorted-append fast path), and `-t` (indexing time); non-BED input is rejected. ([#343](https://github.com/genogrove/genogrove/issues/343), [#421](https://github.com/genogrove/genogrove/pull/421))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(genogrove VERSION 0.24.2)
+project(genogrove VERSION 0.24.3)
 
 find_package(PkgConfig REQUIRED)
 find_package(ZLIB REQUIRED)


### PR DESCRIPTION
## Summary

Patch release **v0.24.3** (from v0.24.2). Bumps `project(genogrove VERSION)` and promotes the `[Unreleased]` CHANGELOG section to `[0.24.3] - 2026-05-21`.

The release is additions, fixes, and refactors with no breaking API change — the one behavior change (#417, `fasta_index::fetch` now throws `std::out_of_range` for an invalid region) is a minor runtime behavior change, not a source-level break — so a patch bump is correct per the project's versioning rule.

Highlights:
- **Added** — `idx` CLI subcommand (BED → `.gg` index), `intersect -i` (search a prebuilt index), `bed_entry`/`block_info` serialization.
- **Fixed** — `split_internal_node` `key_storage` leak; `fasta_index::fetch` exception type (minor behavior change).
- **Refactored** — naming-convention cleanup, `distribute_evenly` helper, reader-base special members.

## Test plan

- [x] I, as a human being, have checked each line of code
- [x] CI is green across the compiler matrix
- [x] `CHANGELOG.md` — `[Unreleased]` is empty; `[0.24.3] - 2026-05-21` carries the release contents
- [x] `CMakeLists.txt` — `project(genogrove VERSION 0.24.3)`

## Follow-ups (after merge)

- Tag the merge commit: annotated `v0.24.3`, push it.
- Create the GitHub release for `v0.24.3`.
- File the `genogrove/docs` version-bump issue (cross-referencing the content-update docs issues #129–#132 from this cycle's feature merges).
