### PR TITLE
fix: guard find_child_pos and name the truncated bam tag (#355, #374)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`find_child_pos` rejects a broken tree invariant**: it returned `siblings.size()` (an out-of-range index) when a node was not among its parent's children; it now throws `std::runtime_error` instead of silently handing back a bad index. ([#374](https://github.com/genogrove/genogrove/issues/374), [#430](https://github.com/genogrove/genogrove/pull/430))
+- **`bam_reader` names the tag in a truncated-aux-data error**: `parse_tags` now reports the last-attempted tag, and `read_next`'s "Truncated auxiliary data at record N" error appends ", last tag: XX" so malformed BAM auxiliary data is diagnosable. ([#355](https://github.com/genogrove/genogrove/issues/355), [#430](https://github.com/genogrove/genogrove/pull/430))
+
 ## [0.24.3] - 2026-05-21
 
 ### Added

--- a/include/genogrove/io/bam_reader.hpp
+++ b/include/genogrove/io/bam_reader.hpp
@@ -443,8 +443,10 @@ namespace genogrove::io {
         cigar_string parse_cigar(const bam1_t* b) const;
 
         /// Parse auxiliary tags from bam1_t
-        /// Sets truncated=true if aux data was malformed/incomplete
-        sam_tags parse_tags(const bam1_t* b, bool& truncated) const;
+        /// Sets truncated=true if aux data was malformed/incomplete; on
+        /// truncation, last_tag is the name of the tag being parsed (empty if
+        /// truncation occurred between tags, before a tag name was read).
+        sam_tags parse_tags(const bam1_t* b, bool& truncated, std::string& last_tag) const;
 
         /// Parse a 'B'-type tag array, advancing aux past the consumed bytes
         /// Returns false if the array is truncated or malformed

--- a/include/genogrove/structure/grove/grove_remove.ipp
+++ b/include/genogrove/structure/grove/grove_remove.ipp
@@ -103,7 +103,14 @@ private:
     /// Find a node's position in its parent's children vector
     int find_child_pos(node<key_type, data_type>* n) const {
         auto& siblings = n->get_parent()->get_children();
-        return static_cast<int>(std::ranges::find(siblings, n) - siblings.begin());
+        auto it = std::ranges::find(siblings, n);
+        if (it == siblings.end()) {
+            // Broken tree invariant: a node's parent must list it as a child.
+            // Returning end() - begin() here would hand back an out-of-range
+            // index and corrupt the caller silently.
+            throw std::runtime_error("find_child_pos: node is not among its parent's children");
+        }
+        return static_cast<int>(it - siblings.begin());
     }
 
     /**

--- a/src/io/bam_reader.cpp
+++ b/src/io/bam_reader.cpp
@@ -249,9 +249,13 @@ namespace genogrove::io {
 
         // Auxiliary tags
         bool aux_truncated = false;
-        entry.tags = parse_tags(b, aux_truncated);
+        std::string last_aux_tag;
+        entry.tags = parse_tags(b, aux_truncated, last_aux_tag);
         if (aux_truncated) {
             error_message = "Truncated auxiliary data at record " + std::to_string(record_num);
+            if (!last_aux_tag.empty()) {
+                error_message += ", last tag: " + last_aux_tag;
+            }
             throw std::runtime_error(error_message);
         }
     }
@@ -333,9 +337,10 @@ namespace genogrove::io {
         }
     }
 
-    sam_tags bam_reader::parse_tags(const bam1_t* b, bool& truncated) const {
+    sam_tags bam_reader::parse_tags(const bam1_t* b, bool& truncated, std::string& last_tag) const {
         sam_tags result;
         truncated = false;
+        last_tag.clear();
 
         const uint8_t* aux = bam_get_aux(b);
         const uint8_t* aux_end = b->data + b->l_data;
@@ -349,6 +354,7 @@ namespace genogrove::io {
 
             // Tag name (2 chars)
             std::string key(reinterpret_cast<const char*>(aux), 2);
+            last_tag = key;  // reported if a later step in this tag truncates
 
             aux += 2;
             char type = static_cast<char>(*aux++);

--- a/src/io/bam_reader.cpp
+++ b/src/io/bam_reader.cpp
@@ -346,6 +346,10 @@ namespace genogrove::io {
         const uint8_t* aux_end = b->data + b->l_data;
 
         while (aux < aux_end) {
+            // Reset per tag: a truncation reached before the tag name is read
+            // is between tags, so last_tag must not carry over a prior tag.
+            last_tag.clear();
+
             // Each tag needs at least 3 bytes: 2-char name + 1-byte type
             if (aux + 3 > aux_end) {
                 truncated = true;


### PR DESCRIPTION
## Summary

Two cpp-audit bug findings, bundled (both small correctness fixes) — part of the v0.24.4 patch.

- **#374** — `find_child_pos` computed `static_cast<int>(find(siblings, n) - begin())`, which is `siblings.size()` (an out-of-range index) when `n` is not among its parent's children. A broken tree invariant was silently handed back to callers as a bad index. It now throws `std::runtime_error` instead.
- **#355** — `bam_reader::parse_tags` returned a partial tag map on truncated aux data with no indication of where parsing stopped. `parse_tags` now reports the last-attempted tag name through a new `std::string& last_tag` out-parameter; `read_next` appends it to the truncation error (`"Truncated auxiliary data at record N, last tag: XX"`), so malformed BAM aux data is diagnosable.

No new tests: #374's throw path requires a corrupt tree not reachable through the public API, and #355 would need a hand-crafted malformed binary BAM fixture — both impractical to unit-test. The changes are a defensive guard and an error-message enrichment; existing suites verify no regression.

## Test plan

- [x] I, as a human being, have checked each line of code
- [x] Full build passes across the CI compiler matrix
- [x] Existing `grove_remove` / `GroveRemoveTest` suites pass — `find_child_pos`'s success path is unchanged
- [x] Existing `bamfile-test` suite passes — `parse_tags`' success path is unchanged; only the truncation error message is enriched

Closes #355
Closes #374

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for BAM file parsing: when auxiliary data is truncated, the last read tag is now captured and included in error messages to make diagnostics clearer.
  * Strengthened tree-structure validation with runtime checks to detect integrity violations early and prevent silent failures or incorrect updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genogrove/genogrove/pull/430?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
