### PR TITLE
perf: micro-opts in query_result ctor and fasta_index::fetch (#356, #366)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Refactored
+- **Perf micro-opts in `query_result` and `fasta_index`**: `query_result`'s constructor moves its by-value query parameter into the member instead of copying it; `fasta_index::fetch(name)` resolves the sequence name once (via `sequence_length`) rather than twice — the post-validation fetch logic is now shared through a `fetch_region` helper. No behavior change. ([#356](https://github.com/genogrove/genogrove/issues/356), [#366](https://github.com/genogrove/genogrove/issues/366), [#431](https://github.com/genogrove/genogrove/pull/431))
+
 ### Fixed
 - **`find_child_pos` rejects a broken tree invariant**: it returned `siblings.size()` (an out-of-range index) when a node was not among its parent's children; it now throws `std::runtime_error` instead of silently handing back a bad index. ([#374](https://github.com/genogrove/genogrove/issues/374), [#430](https://github.com/genogrove/genogrove/pull/430))
 - **`bam_reader` names the tag in a truncated-aux-data error**: `parse_tags` now reports the last-attempted tag, and `read_next`'s "Truncated auxiliary data at record N" error appends ", last tag: XX" so malformed BAM auxiliary data is diagnosable. ([#355](https://github.com/genogrove/genogrove/issues/355), [#430](https://github.com/genogrove/genogrove/pull/430))

--- a/include/genogrove/data_type/query_result.hpp
+++ b/include/genogrove/data_type/query_result.hpp
@@ -8,6 +8,7 @@
 
 // Standard
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 // genogrove
@@ -66,7 +67,7 @@ namespace genogrove::data_type {
              *
              * @param query The query used for intersection (stored by value)
              */
-            explicit query_result(key_t query) : query(query), keys{} {}
+            explicit query_result(key_t query) : query(std::move(query)), keys{} {}
 
             /**
              * @brief Get the original query that produced this result.

--- a/src/io/fasta_index.cpp
+++ b/src/io/fasta_index.cpp
@@ -45,44 +45,55 @@ namespace genogrove::io {
         return *this;
     }
 
+    namespace {
+        // Fetch [start, end) from a sequence whose name has already been
+        // verified to exist in the index. Shared by both fetch() overloads so
+        // the name is resolved only once per call.
+        std::string fetch_region(faidx_t* fai, const std::string& name,
+                                 size_t start, size_t end) {
+            if (start >= end) {
+                throw std::out_of_range("Invalid region: start >= end for " + name);
+            }
+
+            // Guard against size_t→int narrowing (faidx_fetch_seq takes int)
+            constexpr auto kIntMax = static_cast<size_t>(std::numeric_limits<int>::max());
+            if (start > kIntMax || (end - 1) > kIntMax) {
+                throw std::out_of_range("Region exceeds htslib coordinate limit for " + name);
+            }
+
+            // faidx_fetch_seq uses 0-based inclusive coordinates
+            int len = 0;
+            char* seq = faidx_fetch_seq(fai, name.c_str(),
+                                        static_cast<int>(start),
+                                        static_cast<int>(end - 1),
+                                        &len);
+            if (!seq || len < 0) {
+                std::free(seq);
+                throw std::runtime_error("Failed to fetch region " + name +
+                                         ":" + std::to_string(start) + "-" + std::to_string(end));
+            }
+
+            std::string result(seq, static_cast<size_t>(len));
+            std::free(seq);
+            return result;
+        }
+    } // namespace
+
     std::string fasta_index::fetch(const std::string& name, size_t start, size_t end) const {
         if (!faidx_has_seq(fai_, name.c_str())) {
             throw std::out_of_range("Sequence not found in index: " + name);
         }
-
-        if (start >= end) {
-            throw std::out_of_range("Invalid region: start >= end for " + name);
-        }
-
-        // Guard against size_t→int narrowing (faidx_fetch_seq takes int)
-        constexpr auto kIntMax = static_cast<size_t>(std::numeric_limits<int>::max());
-        if (start > kIntMax || (end - 1) > kIntMax) {
-            throw std::out_of_range("Region exceeds htslib coordinate limit for " + name);
-        }
-
-        // faidx_fetch_seq uses 0-based inclusive coordinates
-        int len = 0;
-        char* seq = faidx_fetch_seq(fai_, name.c_str(),
-                                    static_cast<int>(start),
-                                    static_cast<int>(end - 1),
-                                    &len);
-        if (!seq || len < 0) {
-            std::free(seq);
-            throw std::runtime_error("Failed to fetch region " + name +
-                                     ":" + std::to_string(start) + "-" + std::to_string(end));
-        }
-
-        std::string result(seq, static_cast<size_t>(len));
-        std::free(seq);
-        return result;
+        return fetch_region(fai_, name, start, end);
     }
 
     std::string fasta_index::fetch(const std::string& name) const {
+        // sequence_length() already resolves the name (and throws if absent),
+        // so the whole-sequence path skips fetch()'s redundant faidx_has_seq.
         size_t len = sequence_length(name);
         if (len == 0) {
             return {};
         }
-        return fetch(name, 0, len);
+        return fetch_region(fai_, name, 0, len);
     }
 
     size_t fasta_index::sequence_count() const {


### PR DESCRIPTION
## Summary

Two cpp-audit perf findings, bundled — part of the v0.24.4 patch.

- **#356** — `query_result`'s constructor took `key_t query` by value, then copy-constructed the `query` member from it. The by-value parameter is a temporary about to die, so it is now `std::move`d into the member.
- **#366** — `fetch(name)` called `sequence_length()` (one name resolution via `faidx_seq_len`) and then delegated to `fetch(name, 0, len)`, which re-resolved the *same* name via `faidx_has_seq`. The post-validation fetch logic (coordinate guards + `faidx_fetch_seq`) is extracted into a shared `fetch_region()` helper; `fetch(name)` now calls it directly, resolving the name once instead of twice. `fetch(name, start, end)` keeps its `faidx_has_seq` check for the direct-call path.

Behavior and error messages are unchanged — `fetch_region()` carries the exact guards and throw strings the inline code had.

## Test plan

- [x] I, as a human being, have checked each line of code
- [x] Full build passes across the CI compiler matrix
- [x] `indexedfasta-test` passes — both `fetch` overloads, the unknown-sequence throws, and the invalid-region throw still behave identically (they exercise `fetch_region`)

Closes #356
Closes #366

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced memory usage by storing query parameters more efficiently.
  * Centralized and simplified sequence extraction logic for clearer flow and maintainability.
  * Documentation updated to reflect these internal optimizations with no behavioral change.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genogrove/genogrove/pull/431?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
