### PR TITLE
enhancement: mark reader observers and get_edge_list [[nodiscard]] (#359, #373)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`find_child_pos` rejects a broken tree invariant**: it returned `siblings.size()` (an out-of-range index) when a node was not among its parent's children; it now throws `std::runtime_error` instead of silently handing back a bad index. ([#374](https://github.com/genogrove/genogrove/issues/374), [#430](https://github.com/genogrove/genogrove/pull/430))
 - **`bam_reader` names the tag in a truncated-aux-data error**: `parse_tags` now reports the last-attempted tag, and `read_next`'s "Truncated auxiliary data at record N" error appends ", last tag: XX" so malformed BAM auxiliary data is diagnosable. ([#355](https://github.com/genogrove/genogrove/issues/355), [#430](https://github.com/genogrove/genogrove/pull/430))
 
+### Changed
+- **`[[nodiscard]]` on reader observers and `graph_overlay::get_edge_list`**: the `file_reader` observers `has_next` / `get_error_message` / `get_current_line` (base and all four reader overrides) and `graph_overlay::get_edge_list` are now `[[nodiscard]]`, so discarding their result is flagged by the compiler. ([#359](https://github.com/genogrove/genogrove/issues/359), [#373](https://github.com/genogrove/genogrove/issues/373), [#432](https://github.com/genogrove/genogrove/pull/432))
+
 ## [0.24.3] - 2026-05-21
 
 ### Added

--- a/include/genogrove/io/bam_reader.hpp
+++ b/include/genogrove/io/bam_reader.hpp
@@ -372,14 +372,14 @@ namespace genogrove::io {
          * @return true if more records may be available
          * @note This is a best-effort check; read_next() is authoritative
          */
-        bool has_next() override;
+        [[nodiscard]] bool has_next() override;
 
         /**
          * @brief Get the last error message.
          *
          * @return Error message string, empty if no error
          */
-        std::string get_error_message() const override;
+        [[nodiscard]] std::string get_error_message() const override;
 
         /**
          * @brief Get the current record number (1-based).
@@ -391,7 +391,7 @@ namespace genogrove::io {
          *
          * @return Index of the most recently consumed record (0 before the first read)
          */
-        size_t get_current_line() const override;
+        [[nodiscard]] size_t get_current_line() const override;
 
         /**
          * @brief Get the SAM header text.

--- a/include/genogrove/io/bed_reader.hpp
+++ b/include/genogrove/io/bed_reader.hpp
@@ -143,9 +143,9 @@ namespace genogrove::io {
         }
 
         bool read_next(bed_entry& entry) override;
-        bool has_next() override;
-        std::string get_error_message() const override;
-        size_t get_current_line() const override;
+        [[nodiscard]] bool has_next() override;
+        [[nodiscard]] std::string get_error_message() const override;
+        [[nodiscard]] size_t get_current_line() const override;
         ~bed_reader() override;
 
     private:

--- a/include/genogrove/io/fasta_reader.hpp
+++ b/include/genogrove/io/fasta_reader.hpp
@@ -88,9 +88,9 @@ namespace genogrove::io {
         fasta_reader& operator=(fasta_reader&& other) noexcept;
 
         bool read_next(fasta_entry& entry) override;
-        bool has_next() override;
-        std::string get_error_message() const override;
-        size_t get_current_line() const override;
+        [[nodiscard]] bool has_next() override;
+        [[nodiscard]] std::string get_error_message() const override;
+        [[nodiscard]] size_t get_current_line() const override;
         ~fasta_reader() override;
 
     private:

--- a/include/genogrove/io/file_reader.hpp
+++ b/include/genogrove/io/file_reader.hpp
@@ -17,7 +17,7 @@ namespace genogrove::io {
         [[nodiscard]] virtual bool has_next() = 0;
         /// Returns the error message from the most recent read_next() call.
         /// Cleared at the start of each read_next(); empty if the last read succeeded.
-        virtual std::string get_error_message() const = 0;
+        [[nodiscard]] virtual std::string get_error_message() const = 0;
         /// Returns the 1-based position the reader has consumed up to in its input.
         /// The unit is reader-specific: the physical line number for the text
         /// readers (BED/GFF — comment and blank lines are counted), or the record
@@ -26,7 +26,7 @@ namespace genogrove::io {
         /// read_next() — a skipped comment line or a filtered-out record still
         /// advances it. Zero before the first read_next(). Intended for error
         /// messages and progress reporting, not for counting returned entries.
-        virtual size_t get_current_line() const = 0;
+        [[nodiscard]] virtual size_t get_current_line() const = 0;
 
         file_reader_base() = default;
         virtual ~file_reader_base() = default;

--- a/include/genogrove/io/gff_reader.hpp
+++ b/include/genogrove/io/gff_reader.hpp
@@ -125,9 +125,9 @@ namespace genogrove::io {
         }
 
         bool read_next(gff_entry& entry) override;
-        bool has_next() override;
-        std::string get_error_message() const override;
-        size_t get_current_line() const override;
+        [[nodiscard]] bool has_next() override;
+        [[nodiscard]] std::string get_error_message() const override;
+        [[nodiscard]] size_t get_current_line() const override;
         ~gff_reader() override;
 
     private:

--- a/include/genogrove/structure/grove/graph_overlay.hpp
+++ b/include/genogrove/structure/grove/graph_overlay.hpp
@@ -167,7 +167,7 @@ class graph_overlay {
      * @param source Pointer to source key
      * @return Const reference to vector of edges (empty if no edges)
      */
-    const std::vector<edge>& get_edge_list(const gdt::key<key_type, data_type>* source) const {
+    [[nodiscard]] const std::vector<edge>& get_edge_list(const gdt::key<key_type, data_type>* source) const {
         static const std::vector<edge> empty_edges;
         auto it = adjacency.find(source);
         return (it != adjacency.end()) ? it->second : empty_edges;


### PR DESCRIPTION
## Summary

Two cpp-audit `[[nodiscard]]` findings, bundled — part of the v0.24.4 patch.

- **#359** — `file_reader_base`'s observers `get_error_message()` and `get_current_line()`, and every reader's (`bed`/`bam`/`gff`/`fasta`) `has_next` / `get_error_message` / `get_current_line` override, are now `[[nodiscard]]`. `has_next()` was already `[[nodiscard]]` on the base, but the four derived overrides were not — `[[nodiscard]]` is not inherited, so discarding the result through a concrete reader type silently did not warn.
- **#373** — `graph_overlay::get_edge_list()` gains `[[nodiscard]]`; it was the only read-only graph accessor missing it (`get_neighbors`, `get_edges`, `has_edge`, `out_degree`, … all have it).

All of these are pure observers — discarding their result is a useless call. A repo-wide scan confirmed no current call site discards any of them, so this introduces no new warnings.

## Test plan

- [x] I, as a human being, have checked each line of code
- [x] Full build passes across the CI compiler matrix (`[[nodiscard]]` is a compile-time attribute — nothing to unit-test; the build is the verification)
- [x] No new `-Wunused-result` warnings — confirmed by scan, no call site discards these results

Closes #359
Closes #373


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced compiler diagnostics across file reader operations and graph utilities to flag instances where important return values—such as error messages and operational status—might be unintentionally ignored, improving overall code reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genogrove/genogrove/pull/432?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->