### PR TITLE
enhancement: constexpr kmer encode/validate/ctor; key<T,void> default ctor (#365, #381)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **`[[nodiscard]]` on reader observers and `graph_overlay::get_edge_list`**: the `file_reader` observers `has_next` / `get_error_message` / `get_current_line` (base and all four reader overrides) and `graph_overlay::get_edge_list` are now `[[nodiscard]]`, so discarding their result is flagged by the compiler. ([#359](https://github.com/genogrove/genogrove/issues/359), [#373](https://github.com/genogrove/genogrove/issues/373), [#432](https://github.com/genogrove/genogrove/pull/432))
+- **`kmer` constexpr API and `key<T, void>` default construction**: `kmer::encode_base`, `kmer::is_valid`, and the `kmer(encoding, k)` constructor are now `constexpr` (usable in constant expressions). `key<T, void>` — a key with no associated data — is now default-constructible; previously the default constructor's `requires` clause excluded the void-data form. ([#365](https://github.com/genogrove/genogrove/issues/365), [#381](https://github.com/genogrove/genogrove/issues/381), [#433](https://github.com/genogrove/genogrove/pull/433))
 
 ## [0.24.3] - 2026-05-21
 

--- a/include/genogrove/data_type/key.hpp
+++ b/include/genogrove/data_type/key.hpp
@@ -90,6 +90,16 @@ namespace genogrove::data_type {
                 std::default_initializable<data_t> : value{}, data{} {}
 
             /**
+             * @brief Default constructor for the data-less form (data_t = void).
+             *
+             * The requires clause above needs data_t to be default-initializable,
+             * which void is not — so key<T, void> needs its own default ctor.
+             * `data` is std::monostate here and is value-initialized implicitly.
+             */
+            key() requires (std::default_initializable<key_t> && std::is_void_v<data_t>)
+                : value{} {}
+
+            /**
              * @brief Construct a key with the specified key value.
              *
              * When data_t is void: Creates a key with only the value.

--- a/include/genogrove/data_type/kmer.hpp
+++ b/include/genogrove/data_type/kmer.hpp
@@ -6,9 +6,11 @@
 #ifndef GENOGROVE_DATA_TYPE_KMER_HPP
 #define GENOGROVE_DATA_TYPE_KMER_HPP
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <iostream>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 
@@ -88,7 +90,16 @@ namespace genogrove::data_type {
              * @param encoding 2-bit encoded k-mer value
              * @param k Length of the k-mer (1-32)
              */
-            kmer(uint64_t encoding, uint8_t k);
+            constexpr kmer(uint64_t encoding, uint8_t k) : encoding(encoding), k(k) {
+                if (k > max_k) {
+                    throw std::invalid_argument("K-mer length exceeds maximum of 32");
+                }
+                // Mask encoding to only the bits needed for k bases
+                if (k < max_k) {
+                    uint64_t mask = (1ULL << (2 * k)) - 1;
+                    this->encoding = encoding & mask;
+                }
+            }
 
 
             ~kmer() = default;
@@ -221,7 +232,17 @@ namespace genogrove::data_type {
              * @return 2-bit encoding (0-3)
              * @throws std::invalid_argument if base is not A, C, G, or T
              */
-            static uint8_t encode_base(char base);
+            static constexpr uint8_t encode_base(char base) {
+                switch (base) {
+                    case 'A': case 'a': return 0;
+                    case 'C': case 'c': return 1;
+                    case 'G': case 'g': return 2;
+                    case 'T': case 't': return 3;
+                    default:
+                        throw std::invalid_argument(
+                            std::string("Invalid nucleotide: ") + base);
+                }
+            }
 
             /**
              * @brief Decode a 2-bit value to its nucleotide character.
@@ -240,7 +261,12 @@ namespace genogrove::data_type {
              * @param sequence DNA sequence to validate
              * @return true if sequence contains only A, C, G, T (case insensitive)
              */
-            [[nodiscard]] static bool is_valid(std::string_view sequence);
+            [[nodiscard]] static constexpr bool is_valid(std::string_view sequence) {
+                return std::ranges::all_of(sequence, [](char c) {
+                    return c == 'A' || c == 'a' || c == 'C' || c == 'c'
+                        || c == 'G' || c == 'g' || c == 'T' || c == 't';
+                });
+            }
 
         private:
             uint64_t encoding;  ///< 2-bit encoded k-mer (A=00, C=01, G=10, T=11)

--- a/src/data_type/kmer.cpp
+++ b/src/data_type/kmer.cpp
@@ -4,8 +4,6 @@
  */
 
 #include <genogrove/data_type/kmer.hpp>
-#include <algorithm>
-#include <cctype>
 #include <stdexcept>
 
 namespace genogrove::data_type {
@@ -24,17 +22,6 @@ namespace genogrove::data_type {
         k = static_cast<uint8_t>(sequence.length());
         for (char c : sequence) {
             encoding = (encoding << 2) | encode_base(c);
-        }
-    }
-
-    kmer::kmer(uint64_t encoding, uint8_t k) : encoding(encoding), k(k) {
-        if (k > max_k) {
-            throw std::invalid_argument("K-mer length exceeds maximum of 32");
-        }
-        // Mask encoding to only use the bits needed for k bases
-        if (k < max_k) {
-            uint64_t mask = (1ULL << (2 * k)) - 1;
-            this->encoding = encoding & mask;
         }
     }
 
@@ -72,24 +59,6 @@ namespace genogrove::data_type {
             throw std::runtime_error("Failed to deserialize k-mer: stream error");
         }
         return kmer(enc, len);
-    }
-
-    uint8_t kmer::encode_base(char base) {
-        switch (std::toupper(static_cast<unsigned char>(base))) {
-            case 'A': return 0;
-            case 'C': return 1;
-            case 'G': return 2;
-            case 'T': return 3;
-            default:
-                throw std::invalid_argument(std::string("Invalid nucleotide: ") + base);
-        }
-    }
-
-    bool kmer::is_valid(std::string_view sequence) {
-        return std::ranges::all_of(sequence, [](char c) {
-            char upper = std::toupper(static_cast<unsigned char>(c));
-            return upper == 'A' || upper == 'C' || upper == 'G' || upper == 'T';
-        });
     }
 
 }

--- a/tests/data_type/key_test.cpp
+++ b/tests/data_type/key_test.cpp
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * See the LICENSE file in the root of the repository for more information.
+ */
+
+// Google Test
+#include <gtest/gtest.h>
+
+// Standard
+#include <concepts>
+
+// Genogrove
+#include <genogrove/data_type/interval.hpp>
+#include <genogrove/data_type/key.hpp>
+
+namespace gdt = genogrove::data_type;
+
+TEST(keyTest, defaultConstructible) {
+    // #381: key<T, void> (no associated data) must be default-constructible.
+    // The primary default ctor requires data_t to be default-initializable,
+    // which void is not — so the data-less form needs its own default ctor.
+    static_assert(std::default_initializable<gdt::key<gdt::interval>>,
+        "key<T, void> must be default-constructible");
+    static_assert(std::default_initializable<gdt::key<gdt::interval, int>>,
+        "key<T, int> must be default-constructible");
+
+    gdt::key<gdt::interval> k;
+    EXPECT_FALSE(k.has_data());
+}

--- a/tests/data_type/kmer_test.cpp
+++ b/tests/data_type/kmer_test.cpp
@@ -28,6 +28,21 @@ TEST(kmerTest, defaultConstructor) {
     EXPECT_EQ(k.to_string(), "");
 }
 
+TEST(kmerTest, constexprApi) {
+    // #365: encode_base, is_valid, and the (encoding, k) constructor are
+    // constexpr — these static_asserts evaluate them at compile time and
+    // fail to compile if the constexpr is ever dropped.
+    static_assert(gdt::kmer::encode_base('A') == 0);
+    static_assert(gdt::kmer::encode_base('c') == 1);
+    static_assert(gdt::kmer::encode_base('G') == 2);
+    static_assert(gdt::kmer::encode_base('t') == 3);
+    static_assert(gdt::kmer::is_valid("ACGT"));
+    static_assert(gdt::kmer::is_valid("acgt"));
+    static_assert(!gdt::kmer::is_valid("ACGN"));
+    static_assert(gdt::kmer(27, 4).get_k() == 4);
+    static_assert(gdt::kmer(27, 4).get_encoding() == 27);
+}
+
 TEST(kmerTest, stringConstructor) {
     gdt::kmer k1("ACGT");
     EXPECT_EQ(k1.get_k(), 4);


### PR DESCRIPTION
## Summary

The final two cpp-audit findings of the v0.24.4 patch, bundled.

- **#365** — `kmer::encode_base`, `kmer::is_valid`, and the `kmer(uint64_t encoding, uint8_t k)` constructor are now `constexpr`. Their definitions move from `kmer.cpp` into the header — a `constexpr` function must be visible wherever it is constant-evaluated. `encode_base` / `is_valid` drop `std::toupper` (which is **not** `constexpr`) in favour of explicit `A/a C/c G/g T/t` case handling — behavior-equivalent for the nucleotide alphabet. The string constructor `kmer(std::string_view)` stays in `kmer.cpp` (out of scope, not `constexpr`).
- **#381** — `key<T, void>` (no associated data) could not be default-constructed: the primary default ctor's `requires` clause needs `data_t` to be `default_initializable`, and `std::default_initializable<void>` is `false`. Added a second default ctor constrained on `std::is_void_v<data_t>`. The two clauses are mutually exclusive, so there is no ambiguity.

## Test plan

- [x] I, as a human being, have checked each line of code
- [x] Full build passes across the CI compiler matrix
- [x] `kmer_test` passes — new `constexprApi` `static_assert`s evaluate `encode_base` / `is_valid` / the `(encoding, k)` ctor at compile time
- [x] `key_test` (new) passes — `static_assert`s pin `key<interval>` and `key<interval, int>` as default-constructible
- [x] Existing `kmer` tests still pass — `encode_base` / `is_valid` behavior is unchanged for A/C/G/T (case-insensitive)

Closes #365
Closes #381


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Data-less key objects are now default-constructible, simplifying initialization for generic containers and algorithms
  * K-mer operations (nucleotide encoding, sequence validation, construction from raw encoding) now support compile-time evaluation via `constexpr`, enabling use in constant expressions and template contexts

* **Tests**
  * Added validation tests for compile-time functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->