### PR TITLE
Release v0.24.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.4] - 2026-05-22
+
 ### Refactored
 - **Perf micro-opts in `query_result` and `fasta_index`**: `query_result`'s constructor moves its by-value query parameter into the member instead of copying it; `fasta_index::fetch(name)` resolves the sequence name once (via `sequence_length`) rather than twice — the post-validation fetch logic is now shared through a `fetch_region` helper. No behavior change. ([#356](https://github.com/genogrove/genogrove/issues/356), [#366](https://github.com/genogrove/genogrove/issues/366), [#431](https://github.com/genogrove/genogrove/pull/431))
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(genogrove VERSION 0.24.3)
+project(genogrove VERSION 0.24.4)
 
 find_package(PkgConfig REQUIRED)
 find_package(ZLIB REQUIRED)


### PR DESCRIPTION
## Summary

Patch release **v0.24.4** (from v0.24.3). Bumps `project(genogrove VERSION)` and promotes the `[Unreleased]` CHANGELOG section to `[0.24.4] - 2026-05-22`.

The release clears the eight cpp-audit leftover issues tracked under the v0.24.4 milestone — refactors, fixes, and minor enhancements, no breaking API change — so a patch bump is correct.

Highlights:
- **Refactored** — perf micro-opts in `query_result` / `fasta_index::fetch`.
- **Fixed** — `find_child_pos` guards a broken tree invariant; `bam_reader` names the tag in truncated-aux-data errors.
- **Changed** — `[[nodiscard]]` on the reader observers and `graph_overlay::get_edge_list`; `kmer` `encode_base`/`is_valid`/`(encoding,k)` ctor are now `constexpr`; `key<T, void>` is default-constructible.

## Test plan

- [x] I, as a human being, have checked each line of code
- [x] CI is green across the compiler matrix
- [x] `CHANGELOG.md` — `[Unreleased]` is empty; `[0.24.4] - 2026-05-22` carries the release contents
- [x] `CMakeLists.txt` — `project(genogrove VERSION 0.24.4)`

## Follow-ups (after merge)

- Tag the merge commit: annotated `v0.24.4`, push it.
- Create the GitHub release for `v0.24.4`.
- File the `genogrove/docs` version-bump issue.
