### PR TITLE
Release v0.24.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.5] - 2026-05-22
+
 ### Refactored
 - **Revert `query_result` / `flanking_query_result` to non-const key pointers**: `query_result::get_keys()` now returns `const std::vector<key<...>*>&` (non-const pointers) and `flanking_query_result::get_predecessor()` / `get_successor()` return `key<...>*` again, restoring pre-v0.24.x ergonomics. Callers can feed result keys straight back into `grove::add_edge` / `grove::link_if` without a `const_cast`. The const-pointer hardening from #324 / #397 only protected one of several entry points to the same ordering-corruption footgun — `insert_data()` already hands out a mutable pointer — while making the idiomatic call sites uglier; restricting it at `query_result` / `flanking_query_result` alone provided no real protection. ([#435](https://github.com/genogrove/genogrove/issues/435), [#436](https://github.com/genogrove/genogrove/pull/436))
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(genogrove VERSION 0.24.4)
+project(genogrove VERSION 0.24.5)
 
 find_package(PkgConfig REQUIRED)
 find_package(ZLIB REQUIRED)


### PR DESCRIPTION
## Summary

Patch release v0.24.5 — single fix on top of v0.24.4:

- **Revert `query_result` / `flanking_query_result` to non-const key pointers** ([#435](https://github.com/genogrove/genogrove/issues/435), [#436](https://github.com/genogrove/genogrove/pull/436)). `query_result::get_keys()` returns `const std::vector<key<...>*>&` and `flanking_query_result::get_predecessor()` / `get_successor()` return `key<...>*` again, restoring pre-v0.24.x ergonomics. Result keys can be fed straight back into `grove::add_edge` / `grove::link_if` without a `const_cast`.

## QC checklist

- [x] I, as a human being, have checked each line of code
- [x] CI green across the full matrix
- [x] `CHANGELOG.md` — `[Unreleased]` is empty; `[0.24.5] - 2026-05-22` carries the one entry
- [x] `CMakeLists.txt` — `project(genogrove VERSION 0.24.5)`

## Follow-ups

- Tag merge commit on `main`: `git tag -a v0.24.5 -m "Release v0.24.5" && git push origin v0.24.5`
- Create GitHub release `v0.24.5` (notes drawn from CHANGELOG entry)
- File a `genogrove/docs` version-bump issue (`conf.py` version + README badge); cross-ref past version-bump issues (most recent: docs#134 for v0.24.4) and the content-update issue [genogrove/docs#139](https://github.com/genogrove/docs/issues/139)
