### PR TITLE
Fix Doxygen warnings in public header comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Cleared Doxygen warnings in public header comments**: escaped the SAM `@HD`/`@SQ`/`@RG`/`@PG` tags in `bam_reader::get_header()` (Doxygen read them as commands), backticked `##`/`#CHROM` in `vcf_reader::get_header()` (the leading `#` was read as a link request), and converted the `@param` lines documenting the unnamed `sorted_t`/`bulk_t` dispatch tags in `grove_insert.ipp` to `@note` prose (they had no matching argument name). Comment-only; no behavior change. ([#454](https://github.com/genogrove/genogrove/issues/454), [#455](https://github.com/genogrove/genogrove/pull/455))
+
 ## [0.24.7] - 2026-06-13
 
 ### Added

--- a/include/genogrove/io/bam_reader.hpp
+++ b/include/genogrove/io/bam_reader.hpp
@@ -396,7 +396,7 @@ namespace genogrove::io {
         /**
          * @brief Get the SAM header text.
          *
-         * @return Full header text including all @HD, @SQ, @RG, @PG lines
+         * @return Full header text including all @@HD, @@SQ, @@RG, @@PG lines
          */
         [[nodiscard]] const std::string& get_header() const;
 

--- a/include/genogrove/io/vcf_reader.hpp
+++ b/include/genogrove/io/vcf_reader.hpp
@@ -240,7 +240,7 @@ namespace genogrove::io {
          */
         [[nodiscard]] size_t get_current_line() const override;
 
-        /// Full VCF header text (all ## meta lines and the #CHROM column line).
+        /// Full VCF header text (all `##` meta lines and the `#CHROM` column line).
         [[nodiscard]] const std::string& get_header() const;
 
         /// Sample names from the header, in column order (empty for sites-only VCFs).

--- a/include/genogrove/structure/grove/grove_insert.ipp
+++ b/include/genogrove/structure/grove/grove_insert.ipp
@@ -12,7 +12,7 @@ public:
      * @param index The index name (e.g., chromosome name) where the data should be inserted
      * @param key_value The key value to insert (e.g., interval)
      * @param data_value The data associated with the key
-     * @param sorted_t Tag to dispatch to sorted insertion algorithm
+     * @note The trailing sorted_t tag dispatches to the sorted insertion path
      * @note This assumes key_value is greater than all existing keys in the specified index
      * @return Pointer to the inserted key in the tree
      */
@@ -47,8 +47,7 @@ public:
      * @tparam Container A container type holding pairs of (key_type, data_type)
      * @param index The index name (e.g., chromosome name) where data should be inserted
      * @param data Container of sorted (key, data) pairs
-     * @param sorted_t Tag indicating data is already sorted
-     * @param bulk_t Tag for bulk insertion
+     * @note The trailing sorted_t / bulk_t tags dispatch to the sorted bulk insertion path
      * @return Vector of pointers to all inserted keys (in insertion order)
      *
      * @note HYBRID APPROACH:
@@ -138,7 +137,7 @@ public:
      * @tparam Container A container type holding pairs of (key_type, data_type)
      * @param index The index name (e.g., chromosome name) where data should be inserted
      * @param data Container of (key, data) pairs
-     * @param bulk_t Tag for bulk insertion
+     * @note The trailing bulk_t tag dispatches to the bulk insertion path
      * @return Vector of pointers to all inserted keys (in insertion order)
      *
      * @note HYBRID APPROACH:


### PR DESCRIPTION
## Summary
### Changed
- Escape SAM `@HD`/`@SQ`/`@RG`/`@PG` tags in `bam_reader::get_header()` doc comment so Doxygen stops treating them as commands.
- Backtick `##`/`#CHROM` in `vcf_reader::get_header()` doc comment to suppress the spurious link-resolution warning.
- Convert `@param` on the unnamed `sorted_t`/`bulk_t` dispatch-tag params in `grove_insert.ipp` to `@note` prose.

Comment-only changes; no behavior change. Clears the warnings polluting the docs build.

Closes #454

## QC
- [x] I, as a human being, have checked each line of code in this pull request
- [x] `doxygen Doxyfile` over the public headers no longer emits the `@HD`, `#CHROM`, or `@param sorted_t/bulk_t` warnings