### PR TITLE
Extract shared parse_line helper in gff_reader + bed_reader (#457)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Cleared Doxygen warnings in public header comments**: escaped the SAM `@HD`/`@SQ`/`@RG`/`@PG` tags in `bam_reader::get_header()` (Doxygen read them as commands), backticked `##`/`#CHROM` in `vcf_reader::get_header()` (the leading `#` was read as a link request), and converted the `@param` lines documenting the unnamed `sorted_t`/`bulk_t` dispatch tags in `grove_insert.ipp` to `@note` prose (they had no matching argument name). Comment-only; no behavior change. ([#454](https://github.com/genogrove/genogrove/issues/454), [#455](https://github.com/genogrove/genogrove/pull/455))
 
+### Refactored
+- **Extracted a shared `parse_line` helper in `gff_reader` and `bed_reader`**: pulled the per-line field-split, coordinate validation, and field parsing out of `read_next` into a private `parse_line(line, entry)` for both readers, so the streaming path and the upcoming tabix-backed region path ([#456](https://github.com/genogrove/genogrove/issues/456)) share one parser instead of copying it. `read_next` now fetches a line and delegates, owning the skip-vs-throw policy in one place; `parse_line` returns `false` and sets `error_message` on an invalid line. Error-message text and `skip_invalid_lines` semantics are unchanged — including the `catch (std::runtime_error&) { throw; }` layer that propagates infrastructure errors (e.g. a `newlocale` failure in `gff_reader::parse_score`) rather than swallowing them as skipped lines. ([#457](https://github.com/genogrove/genogrove/issues/457), [#459](https://github.com/genogrove/genogrove/pull/459))
+
 ## [0.24.7] - 2026-06-13
 
 ### Added

--- a/include/genogrove/io/bed_reader.hpp
+++ b/include/genogrove/io/bed_reader.hpp
@@ -167,6 +167,11 @@ namespace genogrove::io {
         // Parse optional BED fields (BED4 through BED12)
         bool parse_optional_fields(std::string_view line_sv, size_t& fpos,
                                    bed_entry& entry, size_t start_num, size_t end_num);
+
+        // Parse a single data line into an entry. Returns false and sets
+        // error_message on an invalid line (the caller decides skip vs throw).
+        // Shared by every line source (streaming, and the region path in #456).
+        bool parse_line(const std::string& line, bed_entry& entry);
     };
 
 }

--- a/include/genogrove/io/gff_reader.hpp
+++ b/include/genogrove/io/gff_reader.hpp
@@ -154,6 +154,11 @@ namespace genogrove::io {
 
         // Validate mandatory GTF2 attributes (gene_id, transcript_id)
         bool validate_gtf_attributes(const gff_entry& entry);
+
+        // Parse a single data line into an entry. Returns false and sets
+        // error_message on an invalid line (the caller decides skip vs throw).
+        // Shared by every line source (streaming, and the region path in #456).
+        bool parse_line(const std::string& line, gff_entry& entry);
     };
 
 }

--- a/src/io/bed_reader.cpp
+++ b/src/io/bed_reader.cpp
@@ -344,78 +344,75 @@ namespace genogrove::io {
     bool bed_reader::read_next(bed_entry& entry) {
         while (true) {
             error_message.clear();
-            // Reset optional fields to avoid stale data from previous records
-            entry.name.reset();
-            entry.score.reset();
-            entry.strand.reset();
-            entry.thickness.reset();
-            entry.item_rgb.reset();
-            entry.blocks.reset();
 
             auto line_opt = bgzf_next_data_line(bgzf_file, line_num);
             if (!line_opt) return false;  // EOF
-            const std::string& line = *line_opt;
 
-            // parse the line
-            std::string_view line_sv(line);
-            size_t fpos = 0;
+            if (parse_line(*line_opt, entry)) return true;
+            // Invalid line: error_message already set by parse_line.
+            if (options.skip_invalid_lines) continue;
+            throw std::runtime_error(error_message);
+        }
+    }
 
-            auto chrom_f = ggu::next_field(line_sv, fpos);
-            auto start_f = ggu::next_field(line_sv, fpos);
-            auto end_f = ggu::next_field(line_sv, fpos);
+    bool bed_reader::parse_line(const std::string& line, bed_entry& entry) {
+        // Reset optional fields to avoid stale data from previous records
+        entry.name.reset();
+        entry.score.reset();
+        entry.strand.reset();
+        entry.thickness.reset();
+        entry.item_rgb.reset();
+        entry.blocks.reset();
 
-            try {
-                if (!chrom_f || !start_f || !end_f) {
-                    error_message = "Invalid line format at line " + std::to_string(line_num);
-                    if (options.skip_invalid_lines) continue;
-                    throw std::runtime_error(error_message);
-                }
+        std::string_view line_sv(line);
+        size_t fpos = 0;
 
-                // validate integers
-                if(start_f->empty() ||
-                    end_f->empty() ||
-                    !std::ranges::all_of(*start_f, ggu::is_digit) ||
-                    !std::ranges::all_of(*end_f, ggu::is_digit)) {
-                    error_message = "Invalid coordinate format at line " + std::to_string(line_num);
-                    if (options.skip_invalid_lines) continue;
-                    throw std::runtime_error(error_message);
-                }
+        auto chrom_f = ggu::next_field(line_sv, fpos);
+        auto start_f = ggu::next_field(line_sv, fpos);
+        auto end_f = ggu::next_field(line_sv, fpos);
 
-                // validate and create interval object
-                size_t start_num = 0;
-                size_t end_num = 0;
-                auto [p1, ec1] = std::from_chars(start_f->data(), start_f->data() + start_f->size(), start_num);
-                auto [p2, ec2] = std::from_chars(end_f->data(), end_f->data() + end_f->size(), end_num);
-                if (ec1 != std::errc{} || ec2 != std::errc{}) {
-                    error_message = "Coordinate out of range at line " + std::to_string(line_num);
-                    if (options.skip_invalid_lines) continue;
-                    throw std::runtime_error(error_message);
-                }
-
-                if (start_num >= end_num) {
-                    error_message = "Start coordinate is greater than or equal to the end coordinate at line " + std::to_string(line_num);
-                    if (options.skip_invalid_lines) continue;
-                    throw std::runtime_error(error_message);
-                }
-                entry.chrom = std::string(*chrom_f);
-                entry.start = start_num;
-                entry.end = end_num;
-
-                // Parse optional BED fields (BED4 through BED12)
-                if (!parse_optional_fields(line_sv, fpos, entry, start_num, end_num)) {
-                    // error_message already set by parse_* helper
-                    if (options.skip_invalid_lines) continue;
-                    throw std::runtime_error(error_message);
-                }
-
-                return true;
-            } catch (std::runtime_error&) {
-                throw; // re-throw our own exceptions
-            } catch (std::exception &e) {
-                error_message = "Failed to parse line at " + std::to_string(line_num) + ": " + line;
-                if (options.skip_invalid_lines) continue;
-                throw std::runtime_error(error_message);
+        try {
+            if (!chrom_f || !start_f || !end_f) {
+                error_message = "Invalid line format at line " + std::to_string(line_num);
+                return false;
             }
+
+            // validate integers
+            if(start_f->empty() ||
+                end_f->empty() ||
+                !std::ranges::all_of(*start_f, ggu::is_digit) ||
+                !std::ranges::all_of(*end_f, ggu::is_digit)) {
+                error_message = "Invalid coordinate format at line " + std::to_string(line_num);
+                return false;
+            }
+
+            // validate and create interval object
+            size_t start_num = 0;
+            size_t end_num = 0;
+            auto [p1, ec1] = std::from_chars(start_f->data(), start_f->data() + start_f->size(), start_num);
+            auto [p2, ec2] = std::from_chars(end_f->data(), end_f->data() + end_f->size(), end_num);
+            if (ec1 != std::errc{} || ec2 != std::errc{}) {
+                error_message = "Coordinate out of range at line " + std::to_string(line_num);
+                return false;
+            }
+
+            if (start_num >= end_num) {
+                error_message = "Start coordinate is greater than or equal to the end coordinate at line " + std::to_string(line_num);
+                return false;
+            }
+            entry.chrom = std::string(*chrom_f);
+            entry.start = start_num;
+            entry.end = end_num;
+
+            // Parse optional BED fields (BED4 through BED12)
+            if (!parse_optional_fields(line_sv, fpos, entry, start_num, end_num)) {
+                return false;  // error_message already set by parse_* helper
+            }
+
+            return true;
+        } catch (const std::exception&) {
+            error_message = "Failed to parse line at " + std::to_string(line_num) + ": " + line;
+            return false;
         }
     }
 

--- a/src/io/bed_reader.cpp
+++ b/src/io/bed_reader.cpp
@@ -410,6 +410,8 @@ namespace genogrove::io {
             }
 
             return true;
+        } catch (const std::runtime_error&) {
+            throw;  // propagate infrastructure errors, as before
         } catch (const std::exception&) {
             error_message = "Failed to parse line at " + std::to_string(line_num) + ": " + line;
             return false;

--- a/src/io/gff_reader.cpp
+++ b/src/io/gff_reader.cpp
@@ -313,108 +313,94 @@ namespace genogrove::io {
             error_message.clear();
             auto line_opt = bgzf_next_data_line(bgzf_file, line_num);
             if (!line_opt) return false;  // EOF
-            const std::string& line = *line_opt;
 
-            // parse the line
-            std::string_view line_sv(line);
-            size_t fpos = 0;
+            if (parse_line(*line_opt, entry)) return true;
+            // Invalid line: error_message already set by parse_line.
+            if (options.skip_invalid_lines) continue;
+            throw std::runtime_error(error_message);
+        }
+    }
 
-            auto seqid_f = ggu::next_field(line_sv, fpos);
-            auto source_f = ggu::next_field(line_sv, fpos);
-            auto type_f = ggu::next_field(line_sv, fpos);
-            auto start_f = ggu::next_field(line_sv, fpos);
-            auto end_f = ggu::next_field(line_sv, fpos);
-            auto score_f = ggu::next_field(line_sv, fpos);
-            auto strand_f = ggu::next_field(line_sv, fpos);
-            auto phase_f = ggu::next_field(line_sv, fpos);
+    bool gff_reader::parse_line(const std::string& line, gff_entry& entry) {
+        std::string_view line_sv(line);
+        size_t fpos = 0;
 
-            try {
-                if (!seqid_f || !source_f || !type_f || !start_f || !end_f ||
-                    !score_f || !strand_f || !phase_f) {
-                    error_message = "Invalid GFF line format at line " + std::to_string(line_num);
-                    if (options.skip_invalid_lines) continue;
-                    throw std::runtime_error(error_message);
-                }
+        auto seqid_f = ggu::next_field(line_sv, fpos);
+        auto source_f = ggu::next_field(line_sv, fpos);
+        auto type_f = ggu::next_field(line_sv, fpos);
+        auto start_f = ggu::next_field(line_sv, fpos);
+        auto end_f = ggu::next_field(line_sv, fpos);
+        auto score_f = ggu::next_field(line_sv, fpos);
+        auto strand_f = ggu::next_field(line_sv, fpos);
+        auto phase_f = ggu::next_field(line_sv, fpos);
 
-                // Read the rest of the line as attributes (view into line, no copy)
-                std::string_view attributes_sv;
-                if (fpos < line_sv.size()) {
-                    auto attr_sv = line_sv.substr(fpos);
-                    if (auto p = attr_sv.find_first_not_of(" \t"); p != std::string_view::npos) {
-                        attributes_sv = attr_sv.substr(p);
-                    }
-                }
-
-                // Validate start and end are integers
-                if(start_f->empty() || end_f->empty() ||
-                   !std::ranges::all_of(*start_f, ggu::is_digit) ||
-                   !std::ranges::all_of(*end_f, ggu::is_digit)) {
-                    error_message = "Invalid coordinate format at line " + std::to_string(line_num);
-                    if (options.skip_invalid_lines) continue;
-                    throw std::runtime_error(error_message);
-                }
-
-                // Parse coordinates (stored as 1-based inclusive, native GFF format)
-                size_t start = 0;
-                size_t end = 0;
-                auto [p1, ec1] = std::from_chars(start_f->data(), start_f->data() + start_f->size(), start);
-                auto [p2, ec2] = std::from_chars(end_f->data(), end_f->data() + end_f->size(), end);
-                if (ec1 != std::errc{} || ec2 != std::errc{}) {
-                    error_message = "Coordinate out of range at line " + std::to_string(line_num);
-                    if (options.skip_invalid_lines) continue;
-                    throw std::runtime_error(error_message);
-                }
-
-                if (start > end) {
-                    error_message = "Start coordinate is greater than end coordinate at line " + std::to_string(line_num);
-                    if (options.skip_invalid_lines) continue;
-                    throw std::runtime_error(error_message);
-                }
-
-                entry.seqid = std::string(*seqid_f);
-                entry.source = std::string(*source_f);
-                entry.type = std::string(*type_f);
-                entry.start = start;
-                entry.end = end;
-
-                // Parse score, strand, and phase
-                if (!parse_score(entry, *score_f)) {
-                    if (options.skip_invalid_lines) continue;
-                    throw std::runtime_error(error_message);
-                }
-                if (!parse_strand(entry, *strand_f)) {
-                    if (options.skip_invalid_lines) continue;
-                    throw std::runtime_error(error_message);
-                }
-                if (!parse_phase(entry, *phase_f)) {
-                    if (options.skip_invalid_lines) continue;
-                    throw std::runtime_error(error_message);
-                }
-
-                // Parse attributes and detect format
-                if (!attributes_sv.empty()) {
-                    entry.format = parse_attributes(attributes_sv, entry.attributes);
-                } else {
-                    entry.attributes.clear();
-                    entry.format = gff_format::UNKNOWN;
-                }
-
-                // Validate mandatory GTF2 attributes if enabled
-                if (options.validate_gtf && entry.format == gff_format::GTF) {
-                    if (!validate_gtf_attributes(entry)) {
-                        if (options.skip_invalid_lines) continue;
-                        throw std::runtime_error(error_message);
-                    }
-                }
-
-                return true;
-            } catch (std::runtime_error&) {
-                throw; // re-throw our own exceptions
-            } catch (const std::exception&) {
-                error_message = "Failed to parse line at " + std::to_string(line_num) + ": " + line;
-                if (options.skip_invalid_lines) continue;
-                throw std::runtime_error(error_message);
+        try {
+            if (!seqid_f || !source_f || !type_f || !start_f || !end_f ||
+                !score_f || !strand_f || !phase_f) {
+                error_message = "Invalid GFF line format at line " + std::to_string(line_num);
+                return false;
             }
+
+            // Read the rest of the line as attributes (view into line, no copy)
+            std::string_view attributes_sv;
+            if (fpos < line_sv.size()) {
+                auto attr_sv = line_sv.substr(fpos);
+                if (auto p = attr_sv.find_first_not_of(" \t"); p != std::string_view::npos) {
+                    attributes_sv = attr_sv.substr(p);
+                }
+            }
+
+            // Validate start and end are integers
+            if(start_f->empty() || end_f->empty() ||
+               !std::ranges::all_of(*start_f, ggu::is_digit) ||
+               !std::ranges::all_of(*end_f, ggu::is_digit)) {
+                error_message = "Invalid coordinate format at line " + std::to_string(line_num);
+                return false;
+            }
+
+            // Parse coordinates (stored as 1-based inclusive, native GFF format)
+            size_t start = 0;
+            size_t end = 0;
+            auto [p1, ec1] = std::from_chars(start_f->data(), start_f->data() + start_f->size(), start);
+            auto [p2, ec2] = std::from_chars(end_f->data(), end_f->data() + end_f->size(), end);
+            if (ec1 != std::errc{} || ec2 != std::errc{}) {
+                error_message = "Coordinate out of range at line " + std::to_string(line_num);
+                return false;
+            }
+
+            if (start > end) {
+                error_message = "Start coordinate is greater than end coordinate at line " + std::to_string(line_num);
+                return false;
+            }
+
+            entry.seqid = std::string(*seqid_f);
+            entry.source = std::string(*source_f);
+            entry.type = std::string(*type_f);
+            entry.start = start;
+            entry.end = end;
+
+            // Parse score, strand, and phase
+            if (!parse_score(entry, *score_f)) return false;
+            if (!parse_strand(entry, *strand_f)) return false;
+            if (!parse_phase(entry, *phase_f)) return false;
+
+            // Parse attributes and detect format
+            if (!attributes_sv.empty()) {
+                entry.format = parse_attributes(attributes_sv, entry.attributes);
+            } else {
+                entry.attributes.clear();
+                entry.format = gff_format::UNKNOWN;
+            }
+
+            // Validate mandatory GTF2 attributes if enabled
+            if (options.validate_gtf && entry.format == gff_format::GTF) {
+                if (!validate_gtf_attributes(entry)) return false;
+            }
+
+            return true;
+        } catch (const std::exception&) {
+            error_message = "Failed to parse line at " + std::to_string(line_num) + ": " + line;
+            return false;
         }
     }
 

--- a/src/io/gff_reader.cpp
+++ b/src/io/gff_reader.cpp
@@ -398,6 +398,8 @@ namespace genogrove::io {
             }
 
             return true;
+        } catch (const std::runtime_error&) {
+            throw;  // propagate infrastructure errors (e.g. newlocale failure), as before
         } catch (const std::exception&) {
             error_message = "Failed to parse line at " + std::to_string(line_num) + ": " + line;
             return false;


### PR DESCRIPTION
## Summary

Extracts the per-line parse logic in `gff_reader` and `bed_reader` into a private `parse_line(const std::string& line, <entry>&)`. `read_next` now fetches a line and delegates to `parse_line`, with the skip-vs-throw decision kept in one place.

Pure refactor — **no behavior change**. Error message text and `skip_invalid_lines` semantics are identical: `parse_line` returns `false` and sets `error_message` on an invalid line; `read_next` throws `std::runtime_error(error_message)` (or `continue`s) exactly as before. Each reader now has a single throw site.

This factors the line source apart from the parser so the tabix-backed region path (#456) can reuse the identical parser instead of copying it a third time.

## Changes

- `gff_reader`: new `parse_line`; `read_next` reduced to fetch → delegate.
- `bed_reader`: same extraction; the per-record optional-field reset moves into `parse_line` so any line source gets a clean entry.
- Header declarations for the new private helper in both readers.

Note: `vcf_reader` is intentionally untouched — its parse is already factored into `parse_record`.

## Test plan

- [x] I, as a human being, have checked each line of code
- [x] Existing `gff_reader` / `bed_reader` test suites pass unchanged (no behavior change expected)

Closes #457


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BED and GFF record parsing for more consistent handling of malformed lines.
  * Invalid records can now be skipped or reported with clearer, line-specific error messages based on the existing reader settings.
  * Reduced the chance of stale field values carrying over between records during sequential reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
