### PR TITLE
Block-structured grove serialization (format 0.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Block-structured grove serialization (format 0.2)**: `grove::serialize`/`deserialize` now write a block-structured `.gg` payload instead of a single whole-file zlib stream — each B+ tree node is an independently zlib-compressed, length-prefixed block, external keys are distributed into fixed-size blocks (512/block), and references (child, next-leaf, edge target) are encoded as block ids with a key's global id `(block_id, slot)` doubling as its own locator (so the graph overlay needs no separate key→block index). This is the on-disk foundation for random-access (partial) deserialization; this PR ships the eager reader that round-trips identically. The `.gg` header is bumped to format 0.2 and the 0.1 whole-file stream is no longer readable — no serialization back-compat, regenerate existing indexes. Because each block is inflated from an isolated buffer of exactly its length, the eager reader now reads the source sequentially only: it works on non-seekable sources and preserves trailing data (superseding the [#323](https://github.com/genogrove/genogrove/issues/323) seek-back path). Adds distributed-external-block, cross-chromosome-edge, external-only, and empty-grove round-trip tests. ([#463](https://github.com/genogrove/genogrove/issues/463), [#464](https://github.com/genogrove/genogrove/pull/464))
+
 ## [0.24.8] - 2026-06-29
 
 ### Added

--- a/include/genogrove/io/gg_format.hpp
+++ b/include/genogrove/io/gg_format.hpp
@@ -22,27 +22,33 @@ namespace genogrove::io {
     /// On-disk header for a serialised grove (.gg file).
     ///
     /// The header is 12 bytes of plain (uncompressed) data preceding the
-    /// zlib-compressed grove payload, so a .gg file can be identified and
+    /// block-structured grove payload, so a .gg file can be identified and
     /// validated without decompressing first.
     ///
     /// Layout:
     ///   offset  size  field
     ///        0     4  magic           = "GROV"
-    ///        4     1  format_major    = 0   (pre-1.0; any change may break compatibility)
-    ///        5     1  format_minor    = 1
+    ///        4     1  format_major    = 0   (pre-1.0; format still evolving, may break)
+    ///        5     1  format_minor    = 2   (block-structured payload; see grove serialize)
     ///        6     1  lib_major       = genogrove_VERSION_MAJOR (informational)
     ///        7     1  lib_minor       = genogrove_VERSION_MINOR (informational)
     ///        8     1  lib_patch       = genogrove_VERSION_PATCH (informational)
     ///        9     1  payload_type    (BED = 0x01, GFF = 0x02)
     ///       10     2  reserved        (zero)
     ///
-    /// While CURRENT_FORMAT_MAJOR == 0, read() requires an exact match on
-    /// (format_major, format_minor) and throws std::runtime_error otherwise.
-    /// The lib_* fields are informational only and never cause rejection.
+    /// Format 0.2 is the block-structured, random-access-capable payload:
+    /// a plain directory (per-index root block ids + block metadata) followed by
+    /// independently zlib-compressed, length-prefixed node blocks. The earlier
+    /// whole-file zlib stream (0.1) is not readable by this build — no
+    /// serialization back-compat is maintained; regenerate the index.
+    ///
+    /// While format_major == 0 the format is still evolving. read() requires an
+    /// exact match on (format_major, format_minor) and throws std::runtime_error
+    /// otherwise. The lib_* fields are informational only and never cause rejection.
     struct gg_header {
         static constexpr std::array<char, 4> MAGIC = {'G', 'R', 'O', 'V'};
         static constexpr uint8_t CURRENT_FORMAT_MAJOR = 0;
-        static constexpr uint8_t CURRENT_FORMAT_MINOR = 1;
+        static constexpr uint8_t CURRENT_FORMAT_MINOR = 2;
         static constexpr std::size_t SIZE = 12;
 
         uint8_t format_major = CURRENT_FORMAT_MAJOR;

--- a/include/genogrove/io/gg_format.hpp
+++ b/include/genogrove/io/gg_format.hpp
@@ -38,7 +38,8 @@ namespace genogrove::io {
     ///
     /// Format 0.2 is the block-structured, random-access-capable payload:
     /// a plain directory (per-index root block ids + block metadata) followed by
-    /// independently zlib-compressed, length-prefixed node blocks. The earlier
+    /// independently zlib-compressed, length-prefixed node and external-key
+    /// blocks. The earlier
     /// whole-file zlib stream (0.1) is not readable by this build — no
     /// serialization back-compat is maintained; regenerate the index.
     ///

--- a/include/genogrove/structure/grove/gg_block_format.hpp
+++ b/include/genogrove/structure/grove/gg_block_format.hpp
@@ -12,9 +12,9 @@
 namespace genogrove::structure::detail {
 
 /// Identifier of a single serialized block within a grove stream. Every node
-/// (internal or leaf) is one block; external keys occupy one final block. A
-/// block_id is a dense index in [0, num_blocks) and doubles as the high half of
-/// a key's global id (block_id, slot).
+/// (internal or leaf) is one block; external keys occupy one or more fixed-size
+/// blocks after the node blocks. A block_id is a dense index in [0, num_blocks)
+/// and doubles as the high half of a key's global id (block_id, slot).
 using block_id = std::uint32_t;
 
 /// Sentinel meaning "no block here" — used for the `next` reference of the last

--- a/include/genogrove/structure/grove/gg_block_format.hpp
+++ b/include/genogrove/structure/grove/gg_block_format.hpp
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * See the LICENSE file in the root of the repository for more information.
+ */
+
+#ifndef GENOGROVE_STRUCTURE_GROVE_GG_BLOCK_FORMAT_HPP
+#define GENOGROVE_STRUCTURE_GROVE_GG_BLOCK_FORMAT_HPP
+
+#include <array>
+#include <cstdint>
+
+namespace genogrove::structure::detail {
+
+/// Identifier of a single serialized block within a grove stream. Every node
+/// (internal or leaf) is one block; external keys occupy one final block. A
+/// block_id is a dense index in [0, num_blocks) and doubles as the high half of
+/// a key's global id (block_id, slot).
+using block_id = std::uint32_t;
+
+/// Sentinel meaning "no block here" — used for the `next` reference of the last
+/// leaf in an index's leaf chain (which has no successor).
+inline constexpr block_id no_block = 0xFFFFFFFFu;
+
+/// Magic + version at the very start of a grove serialization stream (distinct
+/// from the CLI-level io::gg_header that wraps a .gg file). Lets grove::deserialize
+/// reject a foreign / older-layout stream with a clear error before parsing. The
+/// trailing byte is the grove-stream format version; bump it on any layout change.
+inline constexpr std::array<char, 4> grove_stream_magic = {'G', 'G', 'B', '\x01'};
+
+} // namespace genogrove::structure::detail
+
+#endif // GENOGROVE_STRUCTURE_GROVE_GG_BLOCK_FORMAT_HPP

--- a/include/genogrove/structure/grove/grove.hpp
+++ b/include/genogrove/structure/grove/grove.hpp
@@ -9,12 +9,18 @@
 // standard
 #include <string_view>
 #include <unordered_map>
+#include <array>
+#include <cstdint>
 #include <deque>
 #include <algorithm>
 #include <functional>
 #include <memory>
 #include <optional>
 #include <queue>
+#include <sstream>
+#include <utility>
+#include <variant>
+#include <vector>
 
 // genogrove
 #include "genogrove/utility/ranges.hpp"
@@ -68,36 +74,6 @@ namespace genogrove::structure {
 
         template<typename T>
         inline constexpr bool is_optional_v = is_optional<T>::value;
-
-        /// DFS pre-order: assign monotonic indices to every key reachable from `n`.
-        /// Used by grove::serialize to flatten the graph overlay into (src, tgt) pairs
-        /// whose indices match the order grove::deserialize repopulates key_storage.
-        template<typename key_type, typename data_type>
-        void index_keys_dfs(const node<key_type, data_type>* n,
-                            std::unordered_map<const gdt::key<key_type, data_type>*, uint32_t>& key_index,
-                            uint32_t& idx) {
-            for (const auto* k : n->get_keys()) { key_index[k] = idx++; }
-            if (!n->get_is_leaf()) {
-                for (const auto* child : n->get_children()) {
-                    index_keys_dfs(child, key_index, idx);
-                }
-            }
-        }
-
-        /// DFS pre-order: collect leaf nodes in left-to-right order.
-        /// Used during deserialization to rebuild the leaf chain.
-        template<typename key_type, typename data_type>
-        void collect_leaves(node<key_type, data_type>* n,
-                            std::vector<node<key_type, data_type>*>& leaves) {
-            if (n == nullptr) return;
-            if (n->get_is_leaf()) {
-                leaves.push_back(n);
-            } else {
-                for (auto* child : n->get_children()) {
-                    collect_leaves(child, leaves);
-                }
-            }
-        }
     }
 
 /**

--- a/include/genogrove/structure/grove/grove.hpp
+++ b/include/genogrove/structure/grove/grove.hpp
@@ -14,6 +14,7 @@
 #include <deque>
 #include <algorithm>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <queue>

--- a/include/genogrove/structure/grove/grove_serialize.ipp
+++ b/include/genogrove/structure/grove/grove_serialize.ipp
@@ -66,157 +66,400 @@ public:
     }
 
     /**
-     * @brief Serialize the grove to a zlib-compressed binary output stream
-     * @param os Output stream to write compressed data to
-     * @note The output is always zlib-compressed
+     * @brief Serialize the grove to a block-structured binary output stream
+     * @param os Output stream to write to
+     *
+     * Format 0.2 (block-structured, random-access-capable):
+     *   [magic "GGB\x01"]
+     *   [directory, plain]: order; per-index (name, root block_id); block count;
+     *       external-block-begin; leaf-key count; external-key count
+     *   [blocks]: each a length-prefixed, independently zlib-compressed record
+     *       - node blocks (id < external-begin), DFS pre-order per index:
+     *           internal → keys + child block_ids;  leaf → keys + next block_id + edges
+     *       - external blocks (id >= external-begin): packed external keys + edges
+     *
+     * Every key's global id is (block_id, slot); graph edges are stored co-located
+     * with their source key as (target_block_id, target_slot[, metadata]). The
+     * per-block compression makes the payload seekable for a future partial read
+     * path; here the whole grove is written.
+     *
+     * @note Blocks are buffered (compressed) in memory to length-prefix them.
+     *       ponytail: fine while groves fit in RAM; revisit with a streaming
+     *       writer + footer index if buffering ever dominates at genome scale.
      */
     void serialize(std::ostream& os) const {
-        detail::deflate_streambuf zbuf(os);
-        std::ostream zos(&zbuf);
+        using key_ptr = const gdt::key<key_type, data_type>*;
 
-        // write the order
-        detail::write_pod(zos, this->order);
+        // ---- Phase 1: assign block ids and key global ids ----
+        std::unordered_map<const node<key_type, data_type>*, detail::block_id> node_to_block;
+        std::vector<const node<key_type, data_type>*> node_blocks;   // block_id -> node
+        std::unordered_map<key_ptr, std::pair<detail::block_id, uint32_t>> key_to_id;
+        std::vector<std::pair<std::string, detail::block_id>> index_roots;
+        uint64_t leaf_keys_total = 0;
 
-        // write the root nodes
-        uint32_t number_root_nodes = static_cast<uint32_t>(this->root_nodes.size());
-        detail::write_pod(zos, number_root_nodes);
-
-        for(const auto& [key, root] : this->root_nodes) {
-            uint32_t index_name_length = static_cast<uint32_t>(key.size());
-            detail::write_pod(zos, index_name_length);
-            zos.write(key.c_str(), index_name_length);
-            root->serialize(zos);
-        }
-
-        // Write external keys
-        uint32_t external_count = static_cast<uint32_t>(external_key_storage.size());
-        detail::write_pod(zos, external_count);
-        for (const auto& key : external_key_storage) {
-            key.serialize(zos);
-        }
-
-        // Write graph overlay edges as flat (source_index, target_index, [metadata]) list.
-        // Key indices must match the order that deserialize() populates key_storage:
-        // DFS pre-order traversal of tree nodes, then external keys.
-        std::unordered_map<const gdt::key<key_type, data_type>*, uint32_t> key_index;
-        {
-            uint32_t idx = 0;
-            for (const auto& [name, root] : root_nodes) {
-                detail::index_keys_dfs(root, key_index, idx);
+        auto assign = [&](const node<key_type, data_type>* n, auto&& self) -> void {
+            detail::block_id id = static_cast<detail::block_id>(node_blocks.size());
+            node_to_block[n] = id;
+            node_blocks.push_back(n);
+            if (n->get_is_leaf()) {
+                const auto& ks = n->get_keys();
+                leaf_keys_total += ks.size();
+                for (uint32_t i = 0; i < ks.size(); ++i) {
+                    key_to_id[ks[i]] = {id, i};
+                }
+            } else {
+                for (const auto* child : n->get_children()) {
+                    self(child, self);
+                }
             }
-            for (const auto& k : external_key_storage) { key_index[&k] = idx++; }
+        };
+        for (const auto& [name, root] : root_nodes) {
+            index_roots.emplace_back(name, static_cast<detail::block_id>(node_blocks.size()));
+            assign(root, assign);
         }
+        const detail::block_id ext_block_begin = static_cast<detail::block_id>(node_blocks.size());
 
-        uint32_t total_edges = static_cast<uint32_t>(graph_data.edge_count());
-        detail::write_pod(zos, total_edges);
+        // External keys are distributed into fixed-size blocks so a partial read
+        // can page in one registry chunk at a time (never the whole registry).
+        // ext_chunk is a compression-vs-granularity knob (see gg_block_format.hpp).
+        constexpr uint32_t ext_chunk = 512;  // ponytail: fixed; tune via benchmark
+        std::vector<std::pair<size_t, size_t>> ext_ranges;  // [begin,end) in external_key_storage
+        for (size_t start = 0; start < external_key_storage.size(); start += ext_chunk) {
+            size_t end = std::min(start + static_cast<size_t>(ext_chunk), external_key_storage.size());
+            detail::block_id id = ext_block_begin + static_cast<detail::block_id>(ext_ranges.size());
+            for (size_t j = start; j < end; ++j) {
+                key_to_id[&external_key_storage[j]] = {id, static_cast<uint32_t>(j - start)};
+            }
+            ext_ranges.emplace_back(start, end);
+        }
+        const detail::block_id num_blocks =
+            ext_block_begin + static_cast<detail::block_id>(ext_ranges.size());
 
-        auto write_edges_for = [&](const auto& storage) {
-            for (const auto& k : storage) {
-                const auto& edges = graph_data.get_edge_list(&k);
+        // ---- Phase 2: compress each block into an in-memory buffer ----
+        // Per-key outgoing edges, written after a key list. Generic over the key
+        // pointer iterator so leaf keys (key*) and external keys (const key*) share it.
+        auto write_key_edges = [&](std::ostream& zos, auto first, auto last) {
+            for (auto it = first; it != last; ++it) {
+                key_ptr k = *it;
+                const auto& edges = graph_data.get_edge_list(k);
+                uint32_t ecount = static_cast<uint32_t>(edges.size());
+                detail::write_pod(zos, ecount);
                 for (const auto& e : edges) {
-                    uint32_t src = key_index.at(&k);
-                    uint32_t tgt = key_index.at(e.target);
-                    detail::write_pod(zos, src);
-                    detail::write_pod(zos, tgt);
+                    auto found = key_to_id.find(e.target);
+                    if (found == key_to_id.end()) {
+                        throw std::runtime_error("Failed to serialize grove: edge target not indexed");
+                    }
+                    detail::block_id tb = found->second.first;
+                    uint32_t ts = found->second.second;
+                    detail::write_pod(zos, tb);
+                    detail::write_pod(zos, ts);
                     if constexpr (!std::is_void_v<edge_data_type>) {
                         gdt::serializer<edge_data_type>::write(zos, e.metadata);
                     }
                 }
             }
         };
-        write_edges_for(key_storage);
-        write_edges_for(external_key_storage);
 
-        if (!zos) {
-            throw std::runtime_error("Failed to serialize grove: stream error");
+        auto compress_block = [](auto&& write_fn) -> std::string {
+            std::ostringstream comp(std::ios::binary);
+            {
+                detail::deflate_streambuf zbuf(comp);
+                std::ostream zos(&zbuf);
+                write_fn(zos);
+                if (!zos) {
+                    throw std::runtime_error("Failed to serialize grove: block stream error");
+                }
+                zbuf.finish();
+            }
+            return comp.str();
+        };
+
+        std::vector<std::string> block_bytes;
+        block_bytes.reserve(num_blocks);
+
+        for (detail::block_id b = 0; b < ext_block_begin; ++b) {
+            const node<key_type, data_type>* n = node_blocks[b];
+            block_bytes.push_back(compress_block([&](std::ostream& zos) {
+                n->serialize_block(zos, node_to_block);
+                if (n->get_is_leaf()) {
+                    write_key_edges(zos, n->get_keys().begin(), n->get_keys().end());
+                }
+            }));
+        }
+        for (const auto& [start, end] : ext_ranges) {
+            block_bytes.push_back(compress_block([&](std::ostream& zos) {
+                uint32_t cnt = static_cast<uint32_t>(end - start);
+                detail::write_pod(zos, cnt);
+                std::vector<key_ptr> keyptrs;
+                keyptrs.reserve(cnt);
+                for (size_t j = start; j < end; ++j) {
+                    const auto& k = external_key_storage[j];
+                    k.get_value().serialize(zos);
+                    if constexpr (!std::is_void_v<data_type>) {
+                        gdt::serializer<data_type>::write(zos, k.get_data());
+                    }
+                    keyptrs.push_back(&k);
+                }
+                write_key_edges(zos, keyptrs.begin(), keyptrs.end());
+            }));
         }
 
-        zbuf.finish();
+        // ---- Phase 3: write magic + directory + length-prefixed blocks ----
+        os.write(detail::grove_stream_magic.data(),
+                 static_cast<std::streamsize>(detail::grove_stream_magic.size()));
+
+        detail::write_pod(os, this->order);
+        uint32_t num_indices = static_cast<uint32_t>(index_roots.size());
+        detail::write_pod(os, num_indices);
+        for (const auto& [name, root_id] : index_roots) {
+            uint32_t name_len = static_cast<uint32_t>(name.size());
+            detail::write_pod(os, name_len);
+            os.write(name.data(), static_cast<std::streamsize>(name_len));
+            detail::block_id rid = root_id;
+            detail::write_pod(os, rid);
+        }
+        detail::write_pod(os, num_blocks);
+        detail::block_id ext_begin_field = ext_block_begin;
+        detail::write_pod(os, ext_begin_field);
+        uint64_t leaf_count_field = leaf_keys_total;
+        detail::write_pod(os, leaf_count_field);
+        uint64_t external_count_field = static_cast<uint64_t>(external_key_storage.size());
+        detail::write_pod(os, external_count_field);
+
+        for (const auto& bytes : block_bytes) {
+            uint64_t clen = static_cast<uint64_t>(bytes.size());
+            detail::write_pod(os, clen);
+            os.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+        }
+
+        if (!os) {
+            throw std::runtime_error("Failed to serialize grove: stream error");
+        }
     }
 
     /**
-     * @brief Deserialize a grove from a zlib-compressed binary input stream
-     * @param is Input stream to read compressed data from
+     * @brief Deserialize a grove from a block-structured binary input stream
+     * @param is Input stream produced by serialize() (format 0.2)
      * @return Deserialized grove object
-     * @note The input must be zlib-compressed
+     *
+     * Eager reader: reads the directory, then reads every length-prefixed block
+     * (each independently inflated from an isolated buffer, so no cross-block
+     * seeking is required — the eager path works on non-seekable sources too),
+     * links child/next references and rebuilds the graph overlay from the
+     * co-located edge records. A future partial-read path will use the same
+     * blocks but load them on demand.
      */
     [[nodiscard]] static grove deserialize(std::istream& is) {
-        detail::inflate_streambuf zbuf(is);
-        std::istream zis(&zbuf);
+        // ---- magic + directory ----
+        std::array<char, 4> magic{};
+        is.read(magic.data(), static_cast<std::streamsize>(magic.size()));
+        if (is.gcount() != static_cast<std::streamsize>(magic.size()) ||
+            magic != detail::grove_stream_magic) {
+            throw std::runtime_error(
+                "Failed to deserialize grove: bad magic (not a format 0.2 grove stream)");
+        }
 
         int order;
-        detail::read_pod(zis, order);
-        if (!zis) {
+        detail::read_pod(is, order);
+        if (!is) {
             throw std::runtime_error("Failed to deserialize grove: stream error reading order");
         }
         grove g(order);
 
-        uint32_t number_root_nodes;
-        detail::read_pod(zis, number_root_nodes);
-        if (!zis) {
-            throw std::runtime_error("Failed to deserialize grove: stream error reading root node count");
+        uint32_t num_indices;
+        detail::read_pod(is, num_indices);
+        if (!is) {
+            throw std::runtime_error("Failed to deserialize grove: stream error reading index count");
         }
-
-        // Deserialize each root node
-        for (uint32_t i = 0; i < number_root_nodes; ++i) {
-            uint32_t index_name_length;
-            detail::read_pod(zis, index_name_length);
-            if (!zis) {
+        std::vector<std::pair<std::string, detail::block_id>> index_roots;
+        index_roots.reserve(num_indices);
+        for (uint32_t i = 0; i < num_indices; ++i) {
+            uint32_t name_len;
+            detail::read_pod(is, name_len);
+            if (!is) {
                 throw std::runtime_error("Failed to deserialize grove: stream error reading index name length");
             }
-            std::string index_name(index_name_length, '\0');
-            zis.read(index_name.data(), static_cast<std::streamsize>(index_name_length));
-            if (!zis) {
+            std::string name(name_len, '\0');
+            is.read(name.data(), static_cast<std::streamsize>(name_len));
+            if (!is) {
                 throw std::runtime_error("Failed to deserialize grove: stream error reading index name");
             }
-
-            node<key_type, data_type>* root = node<key_type, data_type>::deserialize(
-                zis, order, g.key_storage);
-
-            node<key_type, data_type>* rightmost = g.link_leaves_and_find_rightmost(root);
-
-            g.root_nodes[index_name] = root;
-            g.rightmost_nodes[index_name] = rightmost;
+            detail::block_id root_id;
+            detail::read_pod(is, root_id);
+            if (!is) {
+                throw std::runtime_error("Failed to deserialize grove: stream error reading root block id");
+            }
+            index_roots.emplace_back(std::move(name), root_id);
         }
 
-        // Read external keys
-        uint32_t external_count;
-        detail::read_pod(zis, external_count);
-        if (!zis) {
-            throw std::runtime_error("Failed to deserialize grove: stream error reading external key count");
+        detail::block_id num_blocks, ext_block_begin;
+        uint64_t leaf_count_field, external_count_field;
+        detail::read_pod(is, num_blocks);
+        detail::read_pod(is, ext_block_begin);
+        detail::read_pod(is, leaf_count_field);
+        detail::read_pod(is, external_count_field);
+        if (!is) {
+            throw std::runtime_error("Failed to deserialize grove: stream error reading directory");
         }
-        for (uint32_t i = 0; i < external_count; ++i) {
-            g.external_key_storage.push_back(gdt::key<key_type, data_type>::deserialize(zis));
-        }
-
-        // Read graph overlay edges.
-        // Build index → pointer array matching serialization order.
-        std::vector<gdt::key<key_type, data_type>*> key_by_index;
-        key_by_index.reserve(g.key_storage.size() + g.external_key_storage.size());
-        for (auto& k : g.key_storage) { key_by_index.push_back(&k); }
-        for (auto& k : g.external_key_storage) { key_by_index.push_back(&k); }
-
-        uint32_t total_edges;
-        detail::read_pod(zis, total_edges);
-        if (!zis) {
-            throw std::runtime_error("Failed to deserialize grove: stream error reading edge count");
+        if (ext_block_begin > num_blocks) {
+            throw std::runtime_error("Failed to deserialize grove: external-block-begin exceeds block count");
         }
 
-        for (uint32_t i = 0; i < total_edges; ++i) {
-            uint32_t src, tgt;
-            detail::read_pod(zis, src);
-            detail::read_pod(zis, tgt);
+        // Pending edge to resolve after every block is parsed (targets may live
+        // in a block not yet read). Metadata is carried only when present.
+        struct pending_edge {
+            gdt::key<key_type, data_type>* src;
+            detail::block_id tb;
+            uint32_t ts;
+            [[no_unique_address]] std::conditional_t<
+                std::is_void_v<edge_data_type>, std::monostate, edge_data_type> meta;
+        };
+
+        std::vector<node<key_type, data_type>*> block_node(ext_block_begin, nullptr);
+        std::vector<std::vector<detail::block_id>> child_ids(ext_block_begin);
+        std::vector<detail::block_id> next_ids(ext_block_begin, detail::no_block);
+        std::vector<std::vector<gdt::key<key_type, data_type>*>> ext_block_keys(
+            num_blocks - ext_block_begin);
+        std::vector<pending_edge> pending;
+
+        auto read_key_edges = [&](std::istream& zis, gdt::key<key_type, data_type>* src) {
+            uint32_t ecount;
+            detail::read_pod(zis, ecount);
             if (!zis) {
-                throw std::runtime_error("Failed to deserialize grove: stream error reading edge");
+                throw std::runtime_error("Failed to deserialize grove: stream error reading edge count");
             }
-            if (src >= key_by_index.size() || tgt >= key_by_index.size()) {
-                throw std::runtime_error("Failed to deserialize grove: edge index out of range");
+            for (uint32_t i = 0; i < ecount; ++i) {
+                detail::block_id tb;
+                uint32_t ts;
+                detail::read_pod(zis, tb);
+                detail::read_pod(zis, ts);
+                if (!zis) {
+                    throw std::runtime_error("Failed to deserialize grove: stream error reading edge");
+                }
+                if constexpr (std::is_void_v<edge_data_type>) {
+                    pending.push_back(pending_edge{src, tb, ts, {}});
+                } else {
+                    auto meta = gdt::serializer<edge_data_type>::read(zis);
+                    if (!zis) {
+                        throw std::runtime_error("Failed to deserialize grove: stream error reading edge metadata");
+                    }
+                    pending.push_back(pending_edge{src, tb, ts, std::move(meta)});
+                }
             }
-            if constexpr (std::is_void_v<edge_data_type>) {
-                g.graph_data.add_edge(key_by_index[src], key_by_index[tgt]);
+        };
+
+        // ---- read every block (length-prefixed, independently compressed) ----
+        for (detail::block_id b = 0; b < num_blocks; ++b) {
+            uint64_t clen;
+            detail::read_pod(is, clen);
+            if (!is) {
+                throw std::runtime_error("Failed to deserialize grove: stream error reading block length");
+            }
+            std::string cbuf(static_cast<size_t>(clen), '\0');
+            is.read(cbuf.data(), static_cast<std::streamsize>(clen));
+            if (is.gcount() != static_cast<std::streamsize>(clen)) {
+                throw std::runtime_error("Failed to deserialize grove: truncated block");
+            }
+            std::istringstream bs(cbuf, std::ios::binary);
+            detail::inflate_streambuf zbuf(bs);
+            std::istream zis(&zbuf);
+
+            if (b < ext_block_begin) {
+                node<key_type, data_type>* n = node<key_type, data_type>::deserialize_block(
+                    zis, order, g.key_storage, child_ids[b], next_ids[b]);
+                block_node[b] = n;
+                if (n->get_is_leaf()) {
+                    for (auto* k : n->get_keys()) {
+                        read_key_edges(zis, k);
+                    }
+                }
             } else {
-                auto metadata = gdt::serializer<edge_data_type>::read(zis);
-                g.graph_data.add_edge(key_by_index[src], key_by_index[tgt], std::move(metadata));
+                uint32_t cnt;
+                detail::read_pod(zis, cnt);
+                if (!zis) {
+                    throw std::runtime_error("Failed to deserialize grove: stream error reading external block count");
+                }
+                auto& ekeys = ext_block_keys[b - ext_block_begin];
+                ekeys.reserve(cnt);
+                for (uint32_t i = 0; i < cnt; ++i) {
+                    key_type key_value = key_type::deserialize(zis);
+                    if constexpr (std::is_void_v<data_type>) {
+                        g.external_key_storage.emplace_back(key_value);
+                    } else {
+                        data_type data_value = gdt::serializer<data_type>::read(zis);
+                        g.external_key_storage.emplace_back(key_value, data_value);
+                    }
+                    ekeys.push_back(&g.external_key_storage.back());
+                }
+                for (auto* k : ekeys) {
+                    read_key_edges(zis, k);
+                }
+            }
+        }
+
+        // ---- link child / next references ----
+        for (detail::block_id b = 0; b < ext_block_begin; ++b) {
+            node<key_type, data_type>* n = block_node[b];
+            if (n == nullptr) {
+                throw std::runtime_error("Failed to deserialize grove: missing node block");
+            }
+            if (!n->get_is_leaf()) {
+                auto& kids = n->get_children();
+                kids.reserve(child_ids[b].size());
+                for (detail::block_id cid : child_ids[b]) {
+                    if (cid >= ext_block_begin || block_node[cid] == nullptr) {
+                        throw std::runtime_error("Failed to deserialize grove: invalid child block id");
+                    }
+                    block_node[cid]->set_parent(n);
+                    kids.push_back(block_node[cid]);
+                }
+            } else {
+                detail::block_id nid = next_ids[b];
+                if (nid != detail::no_block) {
+                    if (nid >= ext_block_begin || block_node[nid] == nullptr) {
+                        throw std::runtime_error("Failed to deserialize grove: invalid next block id");
+                    }
+                    n->set_next(block_node[nid]);
+                }
+            }
+        }
+
+        // ---- roots + rightmost leaves ----
+        for (const auto& [name, root_id] : index_roots) {
+            if (root_id >= ext_block_begin || block_node[root_id] == nullptr) {
+                throw std::runtime_error("Failed to deserialize grove: invalid root block id");
+            }
+            node<key_type, data_type>* root = block_node[root_id];
+            g.root_nodes[name] = root;
+            node<key_type, data_type>* cur = root;
+            while (!cur->get_is_leaf() && !cur->get_children().empty()) {
+                cur = cur->get_children().back();
+            }
+            g.rightmost_nodes[name] = cur;
+        }
+        g.leaf_key_count = static_cast<size_t>(leaf_count_field);
+
+        // ---- resolve graph edges ----
+        auto resolve_target = [&](detail::block_id tb, uint32_t ts) -> gdt::key<key_type, data_type>* {
+            if (tb < ext_block_begin) {
+                node<key_type, data_type>* tn = block_node[tb];
+                if (tn == nullptr || !tn->get_is_leaf() || ts >= tn->get_keys().size()) {
+                    throw std::runtime_error("Failed to deserialize grove: invalid edge target");
+                }
+                return tn->get_keys()[ts];
+            }
+            detail::block_id ei = tb - ext_block_begin;
+            if (ei >= ext_block_keys.size() || ts >= ext_block_keys[ei].size()) {
+                throw std::runtime_error("Failed to deserialize grove: invalid external edge target");
+            }
+            return ext_block_keys[ei][ts];
+        };
+        for (auto& pe : pending) {
+            gdt::key<key_type, data_type>* tgt = resolve_target(pe.tb, pe.ts);
+            if constexpr (std::is_void_v<edge_data_type>) {
+                g.graph_data.add_edge(pe.src, tgt);
+            } else {
+                g.graph_data.add_edge(pe.src, tgt, std::move(pe.meta));
             }
         }
 
@@ -224,28 +467,3 @@ public:
     }
 
 private:
-    /**
-     * @brief Link leaf nodes together and find the rightmost leaf
-     * @param root Root node of the tree
-     * @return Pointer to the rightmost leaf node
-     * @note Links leaf nodes via their next pointers for range traversal
-     * @note Called during deserialization to restore leaf chain
-     */
-    node<key_type, data_type>* link_leaves_and_find_rightmost(node<key_type, data_type>* root) {
-        if (root == nullptr) return nullptr;
-
-        // Find all leaf nodes via DFS
-        std::vector<node<key_type, data_type>*> leaves;
-        detail::collect_leaves(root, leaves);
-
-        // Link leaves together and count leaf keys
-        for (size_t i = 0; i < leaves.size(); ++i) {
-            this->leaf_key_count += leaves[i]->get_keys().size();
-            if (i + 1 < leaves.size()) {
-                leaves[i]->set_next(leaves[i + 1]);
-            }
-        }
-
-        // Return rightmost leaf
-        return leaves.empty() ? nullptr : leaves.back();
-    }

--- a/include/genogrove/structure/grove/grove_serialize.ipp
+++ b/include/genogrove/structure/grove/grove_serialize.ipp
@@ -264,6 +264,11 @@ public:
         if (!is) {
             throw std::runtime_error("Failed to deserialize grove: stream error reading order");
         }
+        // Validate here (as std::runtime_error, like every other malformed-stream
+        // path) rather than letting grove(order) throw std::invalid_argument.
+        if (order < 3) {
+            throw std::runtime_error("Failed to deserialize grove: order must be >= 3");
+        }
         grove g(order);
 
         uint32_t num_indices;
@@ -348,120 +353,159 @@ public:
             }
         };
 
-        // ---- read every block (length-prefixed, independently compressed) ----
-        for (detail::block_id b = 0; b < num_blocks; ++b) {
-            uint64_t clen;
-            detail::read_pod(is, clen);
-            if (!is) {
-                throw std::runtime_error("Failed to deserialize grove: stream error reading block length");
-            }
-            std::string cbuf(static_cast<size_t>(clen), '\0');
-            is.read(cbuf.data(), static_cast<std::streamsize>(clen));
-            if (is.gcount() != static_cast<std::streamsize>(clen)) {
-                throw std::runtime_error("Failed to deserialize grove: truncated block");
-            }
-            std::istringstream bs(cbuf, std::ios::binary);
-            detail::inflate_streambuf zbuf(bs);
-            std::istream zis(&zbuf);
+        // Node destructors recursively delete children, so on any failure we
+        // free every parsed node whose parent is still null (roots free their
+        // subtrees; non-root nodes are freed via their parent). g.root_nodes is
+        // assigned only on success (below), so this cleanup never races grove's
+        // own ownership. Counts are accumulated for directory validation.
+        uint64_t actual_leaf_key_count = 0;
+        decltype(g.root_nodes) local_roots;
+        decltype(g.rightmost_nodes) local_rightmost;
+        try {
+            // ---- read every block (length-prefixed, independently compressed) ----
+            for (detail::block_id b = 0; b < num_blocks; ++b) {
+                uint64_t clen;
+                detail::read_pod(is, clen);
+                if (!is) {
+                    throw std::runtime_error("Failed to deserialize grove: stream error reading block length");
+                }
+                // clen is file-controlled: reject a value that would overflow the
+                // signed streamsize cast (a negative read count is UB) before it
+                // sizes the buffer.
+                if (clen > static_cast<uint64_t>(std::numeric_limits<std::streamsize>::max())) {
+                    throw std::runtime_error("Failed to deserialize grove: block length out of range");
+                }
+                std::string cbuf(static_cast<size_t>(clen), '\0');
+                is.read(cbuf.data(), static_cast<std::streamsize>(clen));
+                if (is.gcount() != static_cast<std::streamsize>(clen)) {
+                    throw std::runtime_error("Failed to deserialize grove: truncated block");
+                }
+                std::istringstream bs(cbuf, std::ios::binary);
+                detail::inflate_streambuf zbuf(bs);
+                std::istream zis(&zbuf);
 
-            if (b < ext_block_begin) {
-                node<key_type, data_type>* n = node<key_type, data_type>::deserialize_block(
-                    zis, order, g.key_storage, child_ids[b], next_ids[b]);
-                block_node[b] = n;
-                if (n->get_is_leaf()) {
-                    for (auto* k : n->get_keys()) {
+                if (b < ext_block_begin) {
+                    node<key_type, data_type>* n = node<key_type, data_type>::deserialize_block(
+                        zis, order, g.key_storage, child_ids[b], next_ids[b]);
+                    block_node[b] = n;
+                    if (n->get_is_leaf()) {
+                        actual_leaf_key_count += n->get_keys().size();
+                        for (auto* k : n->get_keys()) {
+                            read_key_edges(zis, k);
+                        }
+                    }
+                } else {
+                    uint32_t cnt;
+                    detail::read_pod(zis, cnt);
+                    if (!zis) {
+                        throw std::runtime_error("Failed to deserialize grove: stream error reading external block count");
+                    }
+                    auto& ekeys = ext_block_keys[b - ext_block_begin];
+                    ekeys.reserve(cnt);
+                    for (uint32_t i = 0; i < cnt; ++i) {
+                        key_type key_value = key_type::deserialize(zis);
+                        if constexpr (std::is_void_v<data_type>) {
+                            g.external_key_storage.emplace_back(key_value);
+                        } else {
+                            data_type data_value = gdt::serializer<data_type>::read(zis);
+                            g.external_key_storage.emplace_back(key_value, data_value);
+                        }
+                        ekeys.push_back(&g.external_key_storage.back());
+                    }
+                    for (auto* k : ekeys) {
                         read_key_edges(zis, k);
                     }
                 }
-            } else {
-                uint32_t cnt;
-                detail::read_pod(zis, cnt);
-                if (!zis) {
-                    throw std::runtime_error("Failed to deserialize grove: stream error reading external block count");
+            }
+
+            // ---- link child / next references ----
+            for (detail::block_id b = 0; b < ext_block_begin; ++b) {
+                node<key_type, data_type>* n = block_node[b];
+                if (n == nullptr) {
+                    throw std::runtime_error("Failed to deserialize grove: missing node block");
                 }
-                auto& ekeys = ext_block_keys[b - ext_block_begin];
-                ekeys.reserve(cnt);
-                for (uint32_t i = 0; i < cnt; ++i) {
-                    key_type key_value = key_type::deserialize(zis);
-                    if constexpr (std::is_void_v<data_type>) {
-                        g.external_key_storage.emplace_back(key_value);
-                    } else {
-                        data_type data_value = gdt::serializer<data_type>::read(zis);
-                        g.external_key_storage.emplace_back(key_value, data_value);
+                if (!n->get_is_leaf()) {
+                    auto& kids = n->get_children();
+                    kids.reserve(child_ids[b].size());
+                    for (detail::block_id cid : child_ids[b]) {
+                        if (cid >= ext_block_begin || block_node[cid] == nullptr) {
+                            throw std::runtime_error("Failed to deserialize grove: invalid child block id");
+                        }
+                        // push before set_parent: if push_back throws, the child
+                        // stays parent-less and is freed directly by the guard
+                        // (never both directly and via this parent's subtree).
+                        kids.push_back(block_node[cid]);
+                        block_node[cid]->set_parent(n);
                     }
-                    ekeys.push_back(&g.external_key_storage.back());
-                }
-                for (auto* k : ekeys) {
-                    read_key_edges(zis, k);
+                } else {
+                    detail::block_id nid = next_ids[b];
+                    if (nid != detail::no_block) {
+                        if (nid >= ext_block_begin || block_node[nid] == nullptr) {
+                            throw std::runtime_error("Failed to deserialize grove: invalid next block id");
+                        }
+                        n->set_next(block_node[nid]);
+                    }
                 }
             }
+
+            // ---- roots + rightmost leaves (staged; committed to g below) ----
+            for (const auto& [name, root_id] : index_roots) {
+                if (root_id >= ext_block_begin || block_node[root_id] == nullptr) {
+                    throw std::runtime_error("Failed to deserialize grove: invalid root block id");
+                }
+                node<key_type, data_type>* root = block_node[root_id];
+                local_roots[name] = root;
+                node<key_type, data_type>* cur = root;
+                while (!cur->get_is_leaf() && !cur->get_children().empty()) {
+                    cur = cur->get_children().back();
+                }
+                local_rightmost[name] = cur;
+            }
+
+            // ---- resolve graph edges ----
+            auto resolve_target = [&](detail::block_id tb, uint32_t ts) -> gdt::key<key_type, data_type>* {
+                if (tb < ext_block_begin) {
+                    node<key_type, data_type>* tn = block_node[tb];
+                    if (tn == nullptr || !tn->get_is_leaf() || ts >= tn->get_keys().size()) {
+                        throw std::runtime_error("Failed to deserialize grove: invalid edge target");
+                    }
+                    return tn->get_keys()[ts];
+                }
+                detail::block_id ei = tb - ext_block_begin;
+                if (ei >= ext_block_keys.size() || ts >= ext_block_keys[ei].size()) {
+                    throw std::runtime_error("Failed to deserialize grove: invalid external edge target");
+                }
+                return ext_block_keys[ei][ts];
+            };
+            for (auto& pe : pending) {
+                gdt::key<key_type, data_type>* tgt = resolve_target(pe.tb, pe.ts);
+                if constexpr (std::is_void_v<edge_data_type>) {
+                    g.graph_data.add_edge(pe.src, tgt);
+                } else {
+                    g.graph_data.add_edge(pe.src, tgt, std::move(pe.meta));
+                }
+            }
+
+            // ---- validate the directory counts against what was parsed ----
+            if (actual_leaf_key_count != leaf_count_field) {
+                throw std::runtime_error("Failed to deserialize grove: leaf key count mismatch");
+            }
+            if (static_cast<uint64_t>(g.external_key_storage.size()) != external_count_field) {
+                throw std::runtime_error("Failed to deserialize grove: external key count mismatch");
+            }
+        } catch (...) {
+            for (auto* n : block_node) {
+                if (n != nullptr && n->get_parent() == nullptr) {
+                    delete n;
+                }
+            }
+            throw;
         }
 
-        // ---- link child / next references ----
-        for (detail::block_id b = 0; b < ext_block_begin; ++b) {
-            node<key_type, data_type>* n = block_node[b];
-            if (n == nullptr) {
-                throw std::runtime_error("Failed to deserialize grove: missing node block");
-            }
-            if (!n->get_is_leaf()) {
-                auto& kids = n->get_children();
-                kids.reserve(child_ids[b].size());
-                for (detail::block_id cid : child_ids[b]) {
-                    if (cid >= ext_block_begin || block_node[cid] == nullptr) {
-                        throw std::runtime_error("Failed to deserialize grove: invalid child block id");
-                    }
-                    block_node[cid]->set_parent(n);
-                    kids.push_back(block_node[cid]);
-                }
-            } else {
-                detail::block_id nid = next_ids[b];
-                if (nid != detail::no_block) {
-                    if (nid >= ext_block_begin || block_node[nid] == nullptr) {
-                        throw std::runtime_error("Failed to deserialize grove: invalid next block id");
-                    }
-                    n->set_next(block_node[nid]);
-                }
-            }
-        }
-
-        // ---- roots + rightmost leaves ----
-        for (const auto& [name, root_id] : index_roots) {
-            if (root_id >= ext_block_begin || block_node[root_id] == nullptr) {
-                throw std::runtime_error("Failed to deserialize grove: invalid root block id");
-            }
-            node<key_type, data_type>* root = block_node[root_id];
-            g.root_nodes[name] = root;
-            node<key_type, data_type>* cur = root;
-            while (!cur->get_is_leaf() && !cur->get_children().empty()) {
-                cur = cur->get_children().back();
-            }
-            g.rightmost_nodes[name] = cur;
-        }
+        // ---- commit: grove takes ownership of the trees ----
+        g.root_nodes = std::move(local_roots);
+        g.rightmost_nodes = std::move(local_rightmost);
         g.leaf_key_count = static_cast<size_t>(leaf_count_field);
-
-        // ---- resolve graph edges ----
-        auto resolve_target = [&](detail::block_id tb, uint32_t ts) -> gdt::key<key_type, data_type>* {
-            if (tb < ext_block_begin) {
-                node<key_type, data_type>* tn = block_node[tb];
-                if (tn == nullptr || !tn->get_is_leaf() || ts >= tn->get_keys().size()) {
-                    throw std::runtime_error("Failed to deserialize grove: invalid edge target");
-                }
-                return tn->get_keys()[ts];
-            }
-            detail::block_id ei = tb - ext_block_begin;
-            if (ei >= ext_block_keys.size() || ts >= ext_block_keys[ei].size()) {
-                throw std::runtime_error("Failed to deserialize grove: invalid external edge target");
-            }
-            return ext_block_keys[ei][ts];
-        };
-        for (auto& pe : pending) {
-            gdt::key<key_type, data_type>* tgt = resolve_target(pe.tb, pe.ts);
-            if constexpr (std::is_void_v<edge_data_type>) {
-                g.graph_data.add_edge(pe.src, tgt);
-            } else {
-                g.graph_data.add_edge(pe.src, tgt, std::move(pe.meta));
-            }
-        }
 
         return g;
     }

--- a/include/genogrove/structure/grove/node.hpp
+++ b/include/genogrove/structure/grove/node.hpp
@@ -8,6 +8,7 @@
 
 // standard
 #include <algorithm>
+#include <cstdint>
 #include <deque>
 #include <istream>
 #include <memory>
@@ -15,12 +16,14 @@
 #include <ranges>
 #include <stdexcept>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 // genogrove
 #include "genogrove/data_type/interval.hpp"
 #include "genogrove/data_type/key.hpp"
 #include "genogrove/data_type/serialization_traits.hpp"
+#include "genogrove/structure/grove/gg_block_format.hpp"
 #include "genogrove/structure/grove/pod_io.hpp"
 
 namespace gdt = genogrove::data_type;
@@ -364,29 +367,45 @@ class node {
     // =========================================================================
 
     /**
-     * @brief Serialize this node to an output stream
-     * @param os Output stream to write serialized data to
+     * @brief Serialize this node's own block (non-recursive)
+     * @param os Output stream to write the block's structural bytes to
+     * @param node_to_block Map from every node pointer to its assigned block_id
      *
-     * Writes the node's structure and content to the stream in binary format,
-     * allowing the node to be persisted and later restored.
+     * Writes: a packed header (is_leaf flag + key count), then each key's value
+     * (and data if data_type != void), then the block references — child
+     * block_ids for an internal node, or the single next-leaf block_id (or
+     * detail::no_block) for a leaf. Children are NOT recursed into; each node is
+     * its own independently-addressable block (see grove::serialize).
+     *
+     * @note Per-key graph edges are NOT written here — they live in the grove's
+     *       overlay, not the node. grove::serialize appends a leaf's edges to the
+     *       leaf block after this structural part.
+     * @throws std::runtime_error if a referenced child/next node is absent from
+     *         node_to_block, or on stream error.
      */
-    void serialize(std::ostream& os) const;
+    void serialize_block(std::ostream& os,
+        const std::unordered_map<const node<key_type, data_type>*, detail::block_id>& node_to_block) const;
 
     /**
-     * @brief Deserialize a node from an input stream
-     * @param is Input stream to read serialized data from
-     * @param order The B+ tree order to use for the deserialized node
-     * @param key_storage Deque to allocate keys into for stable pointer addresses
-     * @return Pointer to the newly created and populated node
+     * @brief Parse this node's own block written by serialize_block (non-recursive)
+     * @param is Input stream positioned at the start of the block's structural bytes
+     * @param order The B+ tree order to construct the node with
+     * @param key_storage Deque to emplace keys into for stable pointer addresses
+     * @param out_child_ids Filled with child block_ids for an internal node (empty for a leaf)
+     * @param out_next_id Set to the next-leaf block_id for a leaf (detail::no_block otherwise)
+     * @return Pointer to the newly created node with keys populated
      *
-     * Reads serialized node data from the stream and reconstructs the node
-     * structure, including keys and child relationships. Keys are placed directly
-     * into the provided deque (owned by the grove) rather than heap-allocated,
-     * ensuring pointer stability and single-owner semantics.
+     * Reads only this node's own bytes. Child pointers and the leaf `next` pointer
+     * are left null; the numeric block references are returned via the out-params
+     * for the caller (grove::deserialize) to resolve once every block is parsed.
+     * Keys are emplaced into key_storage (owned by the grove) rather than
+     * heap-allocated, preserving pointer stability and single-owner semantics.
      */
-    [[nodiscard]] static node<key_type, data_type>* deserialize(
+    [[nodiscard]] static node<key_type, data_type>* deserialize_block(
         std::istream& is, int order,
-        std::deque<gdt::key<key_type, data_type>>& key_storage);
+        std::deque<gdt::key<key_type, data_type>>& key_storage,
+        std::vector<detail::block_id>& out_child_ids,
+        detail::block_id& out_next_id);
 
     // =========================================================================
     // Debugging & Utilities
@@ -435,54 +454,73 @@ class node {
 namespace genogrove::structure {
 
 template<typename key_type, typename data_type>
-void node<key_type, data_type>::serialize(std::ostream& os) const {
+void node<key_type, data_type>::serialize_block(std::ostream& os,
+        const std::unordered_map<const node<key_type, data_type>*, detail::block_id>& node_to_block) const {
     // Pack is_leaf into high bit of key count (saves 5B per node vs separate bool + size_t)
     uint32_t packed = static_cast<uint32_t>(keys.size());
     if (is_leaf) packed |= 0x80000000u;
     detail::write_pod(os, packed);
 
-    // Write each key
+    // Write each key: value (+ data if present). NOTE: per-key edges are written
+    // by grove::serialize after this structural part, not here.
     for (const auto* key_ptr : keys) {
-        // Serialize key_type value (requires member serialize method)
         key_ptr->get_value().serialize(os);
-
-        // Serialize data_type if not void (uses serialization_traits)
         if constexpr (!std::is_void_v<data_type>) {
             gdt::serializer<data_type>::write(os, key_ptr->get_data());
         }
     }
 
-    // If not leaf, serialize children
-    if (!is_leaf) {
+    if (is_leaf) {
+        // A leaf references its successor by block_id (no_block if it is the last
+        // leaf in this index's chain). Children are recursed into by the grove as
+        // separate blocks, so nothing recursive happens here.
+        detail::block_id next_id = detail::no_block;
+        if (next != nullptr) {
+            auto it = node_to_block.find(next);
+            if (it == node_to_block.end()) {
+                throw std::runtime_error("Failed to serialize node block: next leaf missing from block map");
+            }
+            next_id = it->second;
+        }
+        detail::write_pod(os, next_id);
+    } else {
         uint32_t num_children = static_cast<uint32_t>(children.size());
         detail::write_pod(os, num_children);
-
-        for (auto* child : children) {
-            child->serialize(os);
+        for (const auto* child : children) {
+            auto it = node_to_block.find(child);
+            if (it == node_to_block.end()) {
+                throw std::runtime_error("Failed to serialize node block: child missing from block map");
+            }
+            detail::block_id child_id = it->second;
+            detail::write_pod(os, child_id);
         }
     }
 
     if (!os) {
-        throw std::runtime_error("Failed to serialize node: stream error");
+        throw std::runtime_error("Failed to serialize node block: stream error");
     }
 }
 
 template<typename key_type, typename data_type>
-node<key_type, data_type>* node<key_type, data_type>::deserialize(
+node<key_type, data_type>* node<key_type, data_type>::deserialize_block(
         std::istream& is, int order,
-        std::deque<gdt::key<key_type, data_type>>& key_storage) {
+        std::deque<gdt::key<key_type, data_type>>& key_storage,
+        std::vector<detail::block_id>& out_child_ids,
+        detail::block_id& out_next_id) {
     auto n = std::make_unique<node<key_type, data_type>>(order);
+    out_child_ids.clear();
+    out_next_id = detail::no_block;
 
     // Unpack is_leaf from high bit + key count from low 31 bits
     uint32_t packed;
     detail::read_pod(is, packed);
     if (!is) {
-        throw std::runtime_error("Failed to deserialize node: stream error reading packed header");
+        throw std::runtime_error("Failed to deserialize node block: stream error reading packed header");
     }
     n->is_leaf = (packed & 0x80000000u) != 0;
     uint32_t num_keys = packed & 0x7FFFFFFFu;
     if (num_keys >= static_cast<uint32_t>(order)) {
-        throw std::runtime_error("Failed to deserialize node: num_keys exceeds order");
+        throw std::runtime_error("Failed to deserialize node block: num_keys exceeds order");
     }
 
     // Read each key directly into grove's deque for stable pointer addresses
@@ -499,22 +537,30 @@ node<key_type, data_type>* node<key_type, data_type>::deserialize(
         n->keys.push_back(&key_storage.back());
     }
 
-    // If not leaf, deserialize children
-    if (!n->is_leaf) {
+    // Read block references (numeric, unresolved). The caller links them once
+    // every block has been parsed. Child pointers / next stay null here.
+    if (n->is_leaf) {
+        detail::read_pod(is, out_next_id);
+        if (!is) {
+            throw std::runtime_error("Failed to deserialize node block: stream error reading next id");
+        }
+    } else {
         uint32_t num_children;
         detail::read_pod(is, num_children);
         if (!is) {
-            throw std::runtime_error("Failed to deserialize node: stream error reading num_children");
+            throw std::runtime_error("Failed to deserialize node block: stream error reading child count");
         }
         if (num_children > static_cast<uint32_t>(order)) {
-            throw std::runtime_error("Failed to deserialize node: num_children exceeds order");
+            throw std::runtime_error("Failed to deserialize node block: num_children exceeds order");
         }
-
-        n->children.reserve(num_children);
+        out_child_ids.reserve(num_children);
         for (uint32_t i = 0; i < num_children; ++i) {
-            auto* child = node<key_type, data_type>::deserialize(is, order, key_storage);
-            child->parent = n.get();
-            n->children.push_back(child);
+            detail::block_id child_id;
+            detail::read_pod(is, child_id);
+            if (!is) {
+                throw std::runtime_error("Failed to deserialize node block: stream error reading child id");
+            }
+            out_child_ids.push_back(child_id);
         }
     }
 

--- a/include/genogrove/structure/grove/node.hpp
+++ b/include/genogrove/structure/grove/node.hpp
@@ -553,6 +553,11 @@ node<key_type, data_type>* node<key_type, data_type>::deserialize_block(
         if (num_children > static_cast<uint32_t>(order)) {
             throw std::runtime_error("Failed to deserialize node block: num_children exceeds order");
         }
+        // B+ tree invariant: an internal node with k separator keys has k+1
+        // children (search_iter descends via get_child(i) for i up to keys.size()).
+        if (num_children != num_keys + 1) {
+            throw std::runtime_error("Failed to deserialize node block: child count does not match key count");
+        }
         out_child_ids.reserve(num_children);
         for (uint32_t i = 0; i < num_children; ++i) {
             detail::block_id child_id;

--- a/tests/structure/serialization_test.cpp
+++ b/tests/structure/serialization_test.cpp
@@ -165,8 +165,8 @@ TEST(SerializationTest, DistributedExternalBlocksRoundTrip) {
         key_t* ext5 = nullptr;
         key_t* ext1029 = nullptr;
         key_t* ext1100 = nullptr;
-        for (int i = 0; i < N; ++i) {
-            key_t* p = g.add_external_key(gdt::interval{10 + i, 11 + i}, i);
+        for (size_t i = 0; i < static_cast<size_t>(N); ++i) {
+            key_t* p = g.add_external_key(gdt::interval{10 + i, 11 + i}, static_cast<int>(i));
             if (i == 5) ext5 = p;
             if (i == 1029) ext1029 = p;
             if (i == 1100) ext1100 = p;

--- a/tests/structure/serialization_test.cpp
+++ b/tests/structure/serialization_test.cpp
@@ -71,16 +71,17 @@ TEST(SerializationTest, FileStreamStateCleanAfterDeserialize) {
     fs::remove(tmp_path);
 }
 
-TEST(SerializationTest, NonSeekableSourceWithTrailingDataThrows) {
-    // Regression test for #323: inflate_streambuf used to call source_.seekg()
-    // to rewind unconsumed bytes after Z_STREAM_END without checking the seek
-    // result. Non-seekable sources (pipes, sockets, custom non-seekable
-    // streambufs) silently failed the seek, dropping the trailing bytes. Now
-    // throws so the caller knows the "concatenated payloads" contract was
-    // violated.
+TEST(SerializationTest, NonSeekableSourceWithTrailingDataRoundTrips) {
+    // Format 1.0 (block-structured) reads each block from an isolated buffer of
+    // exactly its length-prefixed size, so the eager deserialize path only ever
+    // reads the source stream sequentially — it never seeks it. That makes the
+    // eager path work on non-seekable sources (pipes, sockets), and leaves
+    // trailing bytes intact for the caller to read next. This supersedes the
+    // #323 behaviour, where the whole-file zlib stream forced a seek-back on the
+    // source and threw on a non-seekable one.
     //
-    // Type alias is required because EXPECT_THROW is a macro and the comma in
-    // `grove<gdt::interval, int>` would otherwise split the macro args.
+    // Type alias avoids the EXPECT_* macro splitting on the comma in
+    // `grove<gdt::interval, int>`.
     using grove_t = gst::grove<gdt::interval, int>;
 
     std::stringstream payload(std::ios::in | std::ios::out | std::ios::binary);
@@ -88,7 +89,7 @@ TEST(SerializationTest, NonSeekableSourceWithTrailingDataThrows) {
         grove_t g(3);
         g.insert_data("idx", gdt::interval{10, 20}, 1, gst::sorted);
         g.serialize(payload);
-        payload.write("TEST", 4);   // trailing bytes that would normally be rewound
+        payload.write("TEST", 4);   // trailing bytes after the grove
         ASSERT_TRUE(payload.good());
     }
     std::string bytes = payload.str();
@@ -96,15 +97,20 @@ TEST(SerializationTest, NonSeekableSourceWithTrailingDataThrows) {
     non_seekable_streambuf nsb(bytes);
     std::istream is(&nsb);
 
-    EXPECT_THROW({
-        [[maybe_unused]] auto restored = grove_t::deserialize(is);
-    }, std::runtime_error);
+    grove_t restored = grove_t::deserialize(is);
+    EXPECT_EQ(restored.intersect(gdt::interval{10, 20}, "idx").get_keys().size(), 1u);
+
+    // Trailing bytes remain readable — deserialize consumed only the grove.
+    std::array<char, 4> sentinel{};
+    is.read(sentinel.data(), sentinel.size());
+    EXPECT_EQ(is.gcount(), 4);
+    EXPECT_EQ(std::string(sentinel.data(), 4), "TEST");
 }
 
 TEST(SerializationTest, FileStreamStateCleanWithTrailingData) {
-    // Verify that trailing data after the grove is still readable,
-    // confirming inflate_streambuf properly seeks back unconsumed bytes
-    // and leaves the stream in a usable state.
+    // Verify that trailing data after the grove is still readable. Format 0.2
+    // reads exactly each block's length-prefixed bytes, so deserialize consumes
+    // only the grove and leaves the stream positioned at the trailing bytes.
     auto tmp_path = fs::temp_directory_path() / "genogrove_trailing_data_test.bin";
     const std::array<char, 4> sentinel = {'T', 'E', 'S', 'T'};
 
@@ -137,4 +143,125 @@ TEST(SerializationTest, FileStreamStateCleanWithTrailingData) {
     }
 
     fs::remove(tmp_path);
+}
+
+// ==========================================
+// Format 0.2 block-layout coverage
+// ==========================================
+
+TEST(SerializationTest, DistributedExternalBlocksRoundTrip) {
+    // External keys are chunked into fixed-size blocks (512 keys/block), so a
+    // large registry spans several external blocks. Exercise >2 chunks plus
+    // edges whose targets live in a later chunk, to verify (block_id, slot)
+    // resolution across distributed external blocks.
+    using grove_t = gst::grove<gdt::interval, int>;
+    using key_t = gdt::key<gdt::interval, int>;
+    std::stringstream ss(std::ios::in | std::ios::out | std::ios::binary);
+
+    constexpr int N = 1200;  // > 2 * 512 -> 3 external blocks
+    {
+        grove_t g(4);
+        key_t* anchor = g.insert_data("chr1", gdt::interval{1, 2}, -1, gst::sorted);
+        key_t* ext5 = nullptr;
+        key_t* ext1029 = nullptr;
+        key_t* ext1100 = nullptr;
+        for (int i = 0; i < N; ++i) {
+            key_t* p = g.add_external_key(gdt::interval{10 + i, 11 + i}, i);
+            if (i == 5) ext5 = p;
+            if (i == 1029) ext1029 = p;
+            if (i == 1100) ext1100 = p;
+        }
+        g.add_edge(anchor, ext1100);   // indexed -> external in the 3rd chunk
+        g.add_edge(ext5, ext1029);     // external -> external across chunks
+        EXPECT_EQ(g.external_vertex_count(), static_cast<size_t>(N));
+        EXPECT_EQ(g.edge_count(), 2u);
+        g.serialize(ss);
+    }
+    {
+        ss.seekg(0);
+        auto r = grove_t::deserialize(ss);
+        // All external blocks must be read back to recover the full count.
+        EXPECT_EQ(r.external_vertex_count(), static_cast<size_t>(N));
+        EXPECT_EQ(r.edge_count(), 2u);
+
+        auto res = r.intersect(gdt::interval{1, 2}, "chr1");
+        ASSERT_EQ(res.get_keys().size(), 1u);
+        auto neighbors = r.get_neighbors(res.get_keys()[0]);
+        ASSERT_EQ(neighbors.size(), 1u);
+        EXPECT_EQ(neighbors[0]->get_data(), 1100);  // resolved into the 3rd external block
+    }
+}
+
+TEST(SerializationTest, CrossChromosomeEdgeRoundTrip) {
+    // A directed edge between keys on different indices (chromosomes) — the
+    // fusion / trans-regulatory case. Targets resolve into a different index's
+    // node-block range, in both directions.
+    using grove_t = gst::grove<gdt::interval, std::string>;
+    std::stringstream ss(std::ios::in | std::ios::out | std::ios::binary);
+    {
+        grove_t g(4);
+        auto* a = g.insert_data("chr7", gdt::interval{100, 200}, "geneA", gst::sorted);
+        auto* b = g.insert_data("chr9", gdt::interval{300, 400}, "geneB", gst::sorted);
+        g.add_edge(a, b);
+        g.add_edge(b, a);
+        g.serialize(ss);
+    }
+    {
+        ss.seekg(0);
+        auto r = grove_t::deserialize(ss);
+        EXPECT_EQ(r.edge_count(), 2u);
+
+        auto ra = r.intersect(gdt::interval{100, 200}, "chr7");
+        auto rb = r.intersect(gdt::interval{300, 400}, "chr9");
+        ASSERT_EQ(ra.get_keys().size(), 1u);
+        ASSERT_EQ(rb.get_keys().size(), 1u);
+
+        auto na = r.get_neighbors(ra.get_keys()[0]);
+        ASSERT_EQ(na.size(), 1u);
+        EXPECT_EQ(na[0]->get_data(), "geneB");  // chr7 -> chr9
+
+        auto nb = r.get_neighbors(rb.get_keys()[0]);
+        ASSERT_EQ(nb.size(), 1u);
+        EXPECT_EQ(nb[0]->get_data(), "geneA");  // chr9 -> chr7
+    }
+}
+
+TEST(SerializationTest, ExternalOnlyGroveRoundTrip) {
+    // No indexed keys at all -> external-block-begin == 0. The reader must
+    // handle a grove made only of external blocks (no tree, no roots).
+    using grove_t = gst::grove<gdt::interval, int>;
+    std::stringstream ss(std::ios::in | std::ios::out | std::ios::binary);
+    {
+        grove_t g(3);
+        auto* x = g.add_external_key(gdt::interval{1, 2}, 10);
+        auto* y = g.add_external_key(gdt::interval{3, 4}, 20);
+        g.add_edge(x, y);
+        g.serialize(ss);
+    }
+    {
+        ss.seekg(0);
+        auto r = grove_t::deserialize(ss);
+        EXPECT_EQ(r.external_vertex_count(), 2u);
+        EXPECT_EQ(r.indexed_vertex_count(), 0u);
+        EXPECT_EQ(r.edge_count(), 1u);
+        EXPECT_TRUE(r.get_root_nodes().empty());
+    }
+}
+
+TEST(SerializationTest, EmptyGroveRoundTrip) {
+    // No indices and no external keys -> zero blocks. Directory-only stream.
+    using grove_t = gst::grove<gdt::interval, int>;
+    std::stringstream ss(std::ios::in | std::ios::out | std::ios::binary);
+    {
+        grove_t g(3);
+        g.serialize(ss);
+    }
+    {
+        ss.seekg(0);
+        auto r = grove_t::deserialize(ss);
+        EXPECT_EQ(r.vertex_count(), 0u);
+        EXPECT_EQ(r.edge_count(), 0u);
+        EXPECT_TRUE(r.get_root_nodes().empty());
+        EXPECT_EQ(r.intersect(gdt::interval{1, 2}, "absent").get_keys().size(), 0u);
+    }
 }

--- a/tests/structure/serialization_test.cpp
+++ b/tests/structure/serialization_test.cpp
@@ -72,7 +72,7 @@ TEST(SerializationTest, FileStreamStateCleanAfterDeserialize) {
 }
 
 TEST(SerializationTest, NonSeekableSourceWithTrailingDataRoundTrips) {
-    // Format 1.0 (block-structured) reads each block from an isolated buffer of
+    // Format 0.2 (block-structured) reads each block from an isolated buffer of
     // exactly its length-prefixed size, so the eager deserialize path only ever
     // reads the source stream sequentially — it never seeks it. That makes the
     // eager path work on non-seekable sources (pipes, sockets), and leaves


### PR DESCRIPTION
## Summary

Reworks grove `serialize`/`deserialize` from a single whole-file zlib stream into a **block-structured payload**: each B+ tree node is its own independently-compressed, length-prefixed block. This is the on-disk foundation for **random-access (partial) deserialization** (#463) — reading only the nodes a query walks, including across chromosomes via graph edges — without loading the whole file.

This PR ships the format + an **eager** reader that round-trips identically. The lazy/partial read path is a follow-up (PR 2).

## Design

References become **locators**: a node stores the `block_id` of what it points to (children, next-leaf), not an inline subtree. A key's global id `(block_id, slot)` doubles as its own locator, so the graph overlay needs no separate key→block index — resolving an edge target just loads that block and indexes the slot.

## On-disk format (0.2)

```
[magic "GGB\x01"]
[directory, plain]  order; per-index (name, root block_id); block count;
                    external-block-begin; leaf-key count; external-key count
[block]…            each: [u64 clen][zlib bytes], independently compressed
   node blocks (id < ext-begin), DFS pre-order:  internal → keys + child ids
                                                 leaf → keys + next id + per-key edges
   external blocks (id ≥ ext-begin):             packed keys + per-key edges
```

- **External keys are distributed** into fixed-size blocks (512/block) so a future partial read pages one registry chunk at a time rather than reloading an entire enhancer/GWAS registry.
- **Edges are co-located** with their source key (`target block_id, slot[, metadata]`) so landing on a block via an edge brings everything needed to keep hopping.
- **Per-block compression** replaces whole-file compression; page-packing (nodes-per-block) is left as a later tuning knob.

## Behavioral changes

- **format bumped to 0.2** (`format_major = 0` — still evolving). No serialization back-compat (standing project rule): 0.1 `.gg` files must be regenerated.
- **Eager deserialize now works on non-seekable sources** (pipes/sockets) and preserves trailing data. Each block is inflated from an isolated buffer of exactly its length-prefixed size, so the source stream is only ever read sequentially — no cross-block seeking, no reliance on `inflate_streambuf`'s seek-back. This supersedes the `#323` regression; that test is inverted to assert the new (better) behavior.
- CLI needs no change — the `serialize`/`deserialize` signatures are unchanged; the `gg_header` bump is automatic.

## Test coverage

Existing round-trip suites (external keys, node splits, edge chains, compact, const-correctness) are unchanged and still pass. New format-specific tests in `serialization_test.cpp`:

- `DistributedExternalBlocksRoundTrip` — 1200 external keys (3 chunks) + edges resolving into a later chunk and across chunks.
- `CrossChromosomeEdgeRoundTrip` — bidirectional edges between keys on different indices (the fusion / trans-regulatory case).
- `ExternalOnlyGroveRoundTrip` — no indexed keys (external-block-begin == 0).
- `EmptyGroveRoundTrip` — directory-only stream, zero blocks.
- `NonSeekableSourceWithTrailingDataRoundTrips` — the inverted `#323` test.

## Test plan

- [x] I, as a human being, have checked each line of code
- [x] `cmake -S . -B build -DBUILD_TESTING=ON && cmake --build build`
- [x] `cd build && ctest --output-on-failure` (esp. `serialization_test`, `graph_overlay_test`, `grove_remove_test`, `precondition_test`)
- [ ] Regenerate any local `.gg` fixtures (0.1 files are no longer readable)

Refs #463


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new block-structured `.gg` format (format minor 0.2) with independently compressed, length-prefixed blocks and block-id based linking for random-access-friendly storage.
  * Updated grove persistence to use block-oriented node serialization and cross-block edge resolution.
* **Bug Fixes**
  * Improved deserialization behavior on non-seekable inputs with trailing data, preserving unread trailing bytes.
* **Documentation**
  * Documented the format 0.2 header changes and noted loss of readability for format 0.1.
* **Tests**
  * Expanded round-trip coverage for distributed external keys, cross-chromosome edges, external-only groves, and empty groves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
