### PR TITLE
Reject GFF start < 1 in gff_reader (fixes #474)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **GFF `start` coordinate < 1 rejected**: `gff_reader` accepted `start == 0` (it only checked `start > end`), which flowed into the CLI's 0-based conversion `interval(start - 1, end - 1)` and underflowed `size_t` to `SIZE_MAX`, corrupting B+ tree ordering. `start < 1` is now rejected in both the constructor's first-record validation and the per-record `parse_line` path (GFF columns 4/5 are 1-based); the error message names the line. `start == 1` is unaffected. ([#474](https://github.com/genogrove/genogrove/issues/474), [#476](https://github.com/genogrove/genogrove/pull/476))
+
 ## [0.25.0] - 2026-07-08
 
 ### Added

--- a/src/io/gff_reader.cpp
+++ b/src/io/gff_reader.cpp
@@ -144,6 +144,9 @@ namespace genogrove::io {
             if (ec1 != std::errc{} || ec2 != std::errc{}) {
                 throw std::runtime_error("Invalid GFF coordinates (out of range) in " + fpath.string());
             }
+            if (start_num < 1) {
+                throw std::runtime_error("Invalid GFF coordinates (start must be >= 1, GFF is 1-based) in " + fpath.string());
+            }
             if (start_num > end_num) {
                 throw std::runtime_error("Invalid GFF coordinates (start > end) in " + fpath.string());
             }
@@ -374,6 +377,14 @@ namespace genogrove::io {
             auto [p2, ec2] = std::from_chars(end_f->data(), end_f->data() + end_f->size(), end);
             if (ec1 != std::errc{} || ec2 != std::errc{}) {
                 error_message = "Coordinate out of range at line " + std::to_string(line_num);
+                return false;
+            }
+
+            // GFF columns 4/5 are 1-based, so start must be >= 1. Reject 0 here
+            // rather than let a downstream 0-based conversion (start - 1)
+            // underflow (see genogrove#474).
+            if (start < 1) {
+                error_message = "Start coordinate must be >= 1 (GFF is 1-based) at line " + std::to_string(line_num);
                 return false;
             }
 

--- a/tests/io/gfffile-test.cpp
+++ b/tests/io/gfffile-test.cpp
@@ -393,6 +393,40 @@ TEST_F(gfffileTest, validationInvalidCoordinateRange) {
     fs::remove(temp_file);
 }
 
+TEST_F(gfffileTest, validationRejectsZeroStart) {
+    // GFF is 1-based, so start == 0 is malformed; it must be rejected rather
+    // than flow into a 0-based conversion and underflow (genogrove#474).
+    fs::path temp_file = test_data_dir / "temp_zero_start.gff";
+    std::ofstream out(temp_file);
+    out << "chr1\tHAVANA\tgene\t0\t500\t.\t+\t.\tID=gene1\n";  // start == 0
+    out.close();
+
+    // Constructor validates the first record and throws.
+    EXPECT_THROW({
+        gio::gff_reader reader(temp_file);
+    }, std::runtime_error);
+
+    fs::remove(temp_file);
+}
+
+TEST_F(gfffileTest, readNextRejectsZeroStart) {
+    // Per-record parse path (parse_line) must also reject start == 0: a valid
+    // first record followed by a zero-start record throws by default.
+    fs::path temp_file = test_data_dir / "temp_zero_start_second.gff";
+    std::ofstream out(temp_file);
+    out << "chr1\tHAVANA\tgene\t100\t500\t.\t+\t.\tID=gene1\n";  // valid
+    out << "chr1\tHAVANA\tgene\t0\t400\t.\t+\t.\tID=gene2\n";    // start == 0
+    out.close();
+
+    gio::gff_reader reader(temp_file);
+    gio::gff_entry entry;
+    ASSERT_TRUE(reader.read_next(entry));
+    EXPECT_EQ(entry.start, 100u);
+    EXPECT_THROW(reader.read_next(entry), std::runtime_error);
+
+    fs::remove(temp_file);
+}
+
 TEST_F(gfffileTest, validationEmptyFile) {
     // Empty file: structurally valid but zero records. Constructor must not
     // throw; iterator must immediately equal end(). See #310.


### PR DESCRIPTION
## Summary

Closes #474.

### Fixed

`gff_reader` accepted a `start == 0` coordinate (it only validated `start > end`). GFF columns 4/5 are **1-based**, so `start == 0` is malformed — and since #473 it flows into the CLI's 0-based conversion `interval(start - 1, end - 1)`, where `start - 1` underflows `size_t` to `SIZE_MAX`, producing a garbage interval that corrupts B+ tree ordering.

Now `start < 1` is rejected in both coordinate-validation paths:
- the constructor's first-record validation (throws `std::runtime_error`),
- the per-record `parse_line` path (sets `error_message`, honoring `skip_invalid_lines`).

The error message names the line. `start == 1` (the minimum valid GFF start) is unaffected. Fixing it in the reader protects every `gff_reader` consumer, not just the CLI.

## Test plan

- [x] I, as a human being, have checked each line of code
- [x] `cmake -S . -B build -DBUILD_TESTING=ON && cmake --build build`
- [x] `cd build && ctest --output-on-failure` — new `validationRejectsZeroStart` (constructor) and `readNextRejectsZeroStart` (per-record) GFF tests

Verified locally: a standalone harness confirms the constructor rejects a zero-start first record, `read_next` rejects a later zero-start record, and `start == 1` is still accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for GFF files so records with a start coordinate of `0` are now rejected.
  * Parsing now stops with an error when invalid 1-based coordinates are encountered, helping prevent malformed data from being accepted.
* **Tests**
  * Added coverage for files with invalid start coordinates in both initial file loading and later record parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
