### PR TITLE
Release v0.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.1] - 2026-07-09
+
 ### Fixed
 - **GFF `start` coordinate < 1 rejected**: `gff_reader` accepted `start == 0` (it only checked `start > end`), which flowed into the CLI's 0-based conversion `interval(start - 1, end - 1)` and underflowed `size_t` to `SIZE_MAX`, corrupting B+ tree ordering. `start < 1` is now rejected in both the constructor's first-record validation and the per-record `parse_line` path (GFF columns 4/5 are 1-based); the error message names the line. `start == 1` is unaffected. ([#474](https://github.com/genogrove/genogrove/issues/474), [#476](https://github.com/genogrove/genogrove/pull/476))
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(genogrove VERSION 0.25.0)
+project(genogrove VERSION 0.25.1)
 
 find_package(PkgConfig REQUIRED)
 find_package(ZLIB REQUIRED)


### PR DESCRIPTION
## Summary

Release v0.25.1 — a patch release (fix-only). Bumps `project(genogrove VERSION)` to 0.25.1 and promotes `## [Unreleased]` to `## [0.25.1] - 2026-07-09`.

### Fixed
- **GFF `start < 1` rejected** in `gff_reader` — closes #474 (would underflow `size_t` in the CLI's 0-based conversion). ([#474](https://github.com/genogrove/genogrove/issues/474), [#476](https://github.com/genogrove/genogrove/pull/476))

No new features, no format changes — v0.25.0 indexes remain compatible.

## Test plan

- [ ] I, as a human being, have checked each line of code
- [x] CI green across the build matrix
- [x] `CHANGELOG.md` `[Unreleased]` emptied; `[0.25.1] - 2026-07-09` dated
- [x] `CMakeLists.txt` version is 0.25.1

## Follow-ups (after merge)
- Tag `v0.25.1` on the merge commit + create the GitHub release.
- Docs version-bump issue in `genogrove/docs`.


