### PR TITLE
Add get_edge_list to grove_view (parity with graph_overlay) (fixes #504)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`grove_view::get_edge_list` — targets paired with edge metadata**: the partial (random-access) reader gains `get_edge_list(source)`, returning `std::vector<std::pair<key_t*, edge_data_type>>` so each resolved target is paired with its edge payload in one call, matching `graph_overlay::get_edge_list` and saving consumers from zipping `get_neighbors` + `get_edges`. Because the view stores lazy adjacency (`edge_ref { block_id; ts; meta }`), it resolves each target via `resolve_target` on demand (mirroring `get_neighbors`) rather than returning a reference to a stored vector; returns edges in adjacency order, throws `std::invalid_argument` on a null source (consistent with the target-resolving `get_neighbors`/`get_neighbors_if`), and an empty vector for a source with no edges. Constrained to non-`void` `edge_data_type`. Read path only — no format change; unblocks the pygenogrove `GroveView.get_edge_list` binding. ([#504](https://github.com/genogrove/genogrove/issues/504), [#505](https://github.com/genogrove/genogrove/pull/505))
+
 ## [0.25.3] - 2026-07-16
 
 ### Added

--- a/include/genogrove/structure/grove/grove_view.hpp
+++ b/include/genogrove/structure/grove/grove_view.hpp
@@ -221,6 +221,32 @@ class grove_view {
         return out;
     }
 
+    /**
+     * @brief Each outgoing target of `source` paired with its edge metadata, in edge order.
+     *
+     * Only available when edge_data_type is non-void. Resolves targets on demand
+     * exactly like get_neighbors, so it throws std::invalid_argument on a null
+     * source (unlike the metadata-only get_edges, which returns empty). Parity
+     * with graph_overlay::get_edge_list. Empty vector for a source with no edges.
+     */
+    template <typename M = edge_data_type>
+    [[nodiscard]] std::vector<std::pair<key_t*, M>> get_edge_list(const key_t* source)
+        requires(!std::is_void_v<edge_data_type>) {
+        if (source == nullptr) {
+            throw std::invalid_argument("get_edge_list: source must not be null");
+        }
+        std::vector<std::pair<key_t*, M>> out;
+        auto it = adjacency.find(source);
+        if (it == adjacency.end()) {
+            return out;
+        }
+        out.reserve(it->second.size());
+        for (const auto& e : it->second) {
+            out.emplace_back(resolve_target(e.tb, e.ts), e.meta);
+        }
+        return out;
+    }
+
     /// Blocks paged in so far — for tests asserting a query is actually partial.
     [[nodiscard]] std::size_t blocks_loaded() const { return node_cache.size() + ext_cache.size(); }
     /// Total block count from the directory.

--- a/tests/structure/grove_view_test.cpp
+++ b/tests/structure/grove_view_test.cpp
@@ -184,11 +184,10 @@ TEST(GroveViewTest, EdgePayloadsSurfaceThroughView) {
                         src, [](const std::string& m) { return m == "nonexistent"; })
                     .empty());
 
-    // get_edge_list pairs each resolved target with its metadata, in edge order.
+    // get_edge_list pairs each resolved target with its metadata, in edge order
+    // (insertion order: a->b "strong" then a->c "weak"); no sort — order is asserted.
     auto edge_list = view.get_edge_list(src);
     ASSERT_EQ(edge_list.size(), 2u);
-    std::sort(edge_list.begin(), edge_list.end(),
-              [](const auto& l, const auto& r) { return l.second < r.second; });
     EXPECT_EQ(edge_list[0].first->get_data(), "geneB");  // "strong"
     EXPECT_EQ(edge_list[0].second, "strong");
     EXPECT_EQ(edge_list[1].first->get_data(), "geneC");  // "weak"

--- a/tests/structure/grove_view_test.cpp
+++ b/tests/structure/grove_view_test.cpp
@@ -184,9 +184,20 @@ TEST(GroveViewTest, EdgePayloadsSurfaceThroughView) {
                         src, [](const std::string& m) { return m == "nonexistent"; })
                     .empty());
 
+    // get_edge_list pairs each resolved target with its metadata, in edge order.
+    auto edge_list = view.get_edge_list(src);
+    ASSERT_EQ(edge_list.size(), 2u);
+    std::sort(edge_list.begin(), edge_list.end(),
+              [](const auto& l, const auto& r) { return l.second < r.second; });
+    EXPECT_EQ(edge_list[0].first->get_data(), "geneB");  // "strong"
+    EXPECT_EQ(edge_list[0].second, "strong");
+    EXPECT_EQ(edge_list[1].first->get_data(), "geneC");  // "weak"
+    EXPECT_EQ(edge_list[1].second, "weak");
+
     EXPECT_EQ(view.get_edges(nullptr).size(), 0u);
     EXPECT_THROW(view.get_neighbors_if(nullptr, [](const std::string&) { return true; }),
                  std::invalid_argument);
+    EXPECT_THROW(view.get_edge_list(nullptr), std::invalid_argument);
 
     fs::remove(path);
 }


### PR DESCRIPTION
## Summary

`grove_view` only exposed `get_neighbors` (targets) and `get_edges` (metadata) as separate calls, forcing consumers to zip them and preventing overlay-written code from carrying over. This adds `get_edge_list(source)` returning each resolved target paired with its edge metadata in one step, matching `graph_overlay::get_edge_list`.

Because the view stores lazy adjacency (`edge_ref { block_id tb; uint32_t ts; meta; }`), it can't return a reference to a stored `{target*, meta}` vector like the overlay — it resolves each target via `resolve_target` on demand, mirroring `get_neighbors`.

## Behavior

- `std::vector<std::pair<key_t*, edge_data_type>> get_edge_list(const key_t* source)`, guarded on `!std::is_void_v<edge_data_type>`.
- Resolves targets in adjacency order; pages in target blocks on demand.
- Throws `std::invalid_argument` on null source (consistent with target-resolving `get_neighbors` / `get_neighbors_if`, not the empty-return of `get_edges`).
- Empty vector for a source with no recorded edges.

## Downstream

Unblocks the pygenogrove binding tracked in genogrove/pygenogrove#66.

## Test plan

- [x] I, as a human being, have checked each line of code
- [x] Extended `GroveViewTest.EdgePayloadsSurfaceThroughView` with `get_edge_list` assertions: paired targets + metadata in edge order, and null-source throws.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an edge-list view that returns each connected target together with its associated metadata.
  * Preserves edge order and returns an empty list when no edges are recorded.

* **Bug Fixes**
  * Added validation to reject null source keys when retrieving edge lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->