### PR TITLE
Release v0.25.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.4] - 2026-07-22
+
 ### Added
 - **`grove_view::get_edge_list` — targets paired with edge metadata**: the partial (random-access) reader gains `get_edge_list(source)`, returning `std::vector<std::pair<key_t*, edge_data_type>>` so each resolved target is paired with its edge payload in one call, matching `graph_overlay::get_edge_list` and saving consumers from zipping `get_neighbors` + `get_edges`. Because the view stores lazy adjacency (`edge_ref { block_id; ts; meta }`), it resolves each target via `resolve_target` on demand (mirroring `get_neighbors`) rather than returning a reference to a stored vector; returns edges in adjacency order, throws `std::invalid_argument` on a null source (consistent with the target-resolving `get_neighbors`/`get_neighbors_if`), and an empty vector for a source with no edges. Constrained to non-`void` `edge_data_type`. Read path only — no format change; unblocks the pygenogrove `GroveView.get_edge_list` binding. ([#504](https://github.com/genogrove/genogrove/issues/504), [#505](https://github.com/genogrove/genogrove/pull/505))
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(genogrove VERSION 0.25.3)
+project(genogrove VERSION 0.25.4)
 
 find_package(PkgConfig REQUIRED)
 find_package(ZLIB REQUIRED)


### PR DESCRIPTION
## Summary

Patch release **v0.25.4** — additive + documentation + refactor, no `.gg` format change, no breaking API change. Existing indexes remain compatible.

### Contents (from `[Unreleased]`)

- **Added** — `grove_view::get_edge_list`: targets paired with edge metadata on the partial reader, matching `graph_overlay::get_edge_list` ([#504](https://github.com/genogrove/genogrove/issues/504), [#505](https://github.com/genogrove/genogrove/pull/505)).
- **Changed** — `io` documentation papercuts: `filetype_detector` documents that BGZF (BAM/BCF/bgzipped `.vcf.gz`) reports `GZIP`; corrected the stale `bam_reader` usage example ([#494](https://github.com/genogrove/genogrove/issues/494), [#507](https://github.com/genogrove/genogrove/pull/507)).
- **Refactored** — dropped unused `argc`/`argv` from the CLI subcall option builder; renamed `parse_args` → `build_options` ([#496](https://github.com/genogrove/genogrove/issues/496), [#506](https://github.com/genogrove/genogrove/pull/506)).

## Release mechanics

- Bumped `project(genogrove VERSION 0.25.4)` in `CMakeLists.txt`.
- Promoted `## [Unreleased]` → `## [0.25.4] - 2026-07-22` in `CHANGELOG.md` (empty `[Unreleased]` retained above).

## Test plan

- [x] I, as a human being, have checked each line of code
- [x] CI green across all platforms
- [x] `CHANGELOG.md` — `[Unreleased]` empty, `[0.25.4]` dated with all three entries
- [x] `CMakeLists.txt` — version is `0.25.4`

## Follow-ups (after merge)

- [x] Tag the merge commit: `git tag -a v0.25.4 -m "Release v0.25.4"` && push
- [x] Create the GitHub release for `v0.25.4`
- [x] File the docs version-bump issue in `genogrove/docs` (`conf.py` version + README badge)

