### PR TITLE
Add get_order() and index_names() to grove_view (fixes #509)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`grove_view` read-side introspection: `get_order()` and `get_index_names()`**: the partial (random-access) reader gains two accessors that were present on the in-memory `grove` but had no view equivalent, despite the view already holding the data from `open()`. `get_order()` returns the B+ tree order (mirrors `grove::get_order()`); `get_index_names()` returns `std::vector<std::string>` of every index (e.g. chromosome) in the `.gg`, in unspecified order — the view-appropriate analogue of `grove::get_root_nodes()` (which returns node pointers meaningless to a lazy view), letting a caller discover what `intersect(query)` / `flanking` can run against. Both read nothing extra (no block loads, no format change). Mutation, aggregate graph/key counts, and `grove_to_sif` were deliberately left out — the first is write-only, the latter two would force reading the whole file, contradicting the lazy design. ([#509](https://github.com/genogrove/genogrove/issues/509), [#510](https://github.com/genogrove/genogrove/pull/510))
+
 ## [0.25.4] - 2026-07-22
 
 ### Added

--- a/include/genogrove/structure/grove/grove_view.hpp
+++ b/include/genogrove/structure/grove/grove_view.hpp
@@ -247,6 +247,23 @@ class grove_view {
         return out;
     }
 
+    /// The B+ tree order the `.gg` was built with. Mirrors grove::get_order().
+    [[nodiscard]] int get_order() const { return order; }
+
+    /// Names of every index (e.g. chromosome) in the `.gg`, in unspecified order
+    /// (like grove's unordered root map). The view-appropriate analogue of
+    /// grove::get_root_nodes() — lets a caller discover what intersect(query) /
+    /// flanking can run against. Reads nothing extra: the directory is already
+    /// in memory from open().
+    [[nodiscard]] std::vector<std::string> index_names() const {
+        std::vector<std::string> names;
+        names.reserve(index_roots.size());
+        for (const auto& [name, root_id] : index_roots) {
+            names.push_back(name);
+        }
+        return names;
+    }
+
     /// Blocks paged in so far — for tests asserting a query is actually partial.
     [[nodiscard]] std::size_t blocks_loaded() const { return node_cache.size() + ext_cache.size(); }
     /// Total block count from the directory.

--- a/include/genogrove/structure/grove/grove_view.hpp
+++ b/include/genogrove/structure/grove/grove_view.hpp
@@ -255,7 +255,7 @@ class grove_view {
     /// grove::get_root_nodes() — lets a caller discover what intersect(query) /
     /// flanking can run against. Reads nothing extra: the directory is already
     /// in memory from open().
-    [[nodiscard]] std::vector<std::string> index_names() const {
+    [[nodiscard]] std::vector<std::string> get_index_names() const {
         std::vector<std::string> names;
         names.reserve(index_roots.size());
         for (const auto& [name, root_id] : index_roots) {

--- a/tests/structure/grove_view_test.cpp
+++ b/tests/structure/grove_view_test.cpp
@@ -94,8 +94,8 @@ TEST(GroveViewTest, MatchesEagerIntersectAcrossIndices) {
     EXPECT_EQ(view.get_order(), eager.get_order());  // built with order 4
     EXPECT_EQ(view.get_order(), 4);
 
-    // index_names() enumerates the same indices the eager grove holds, order-independent.
-    std::vector<std::string> view_names = view.index_names();
+    // get_index_names() enumerates the same indices the eager grove holds, order-independent.
+    std::vector<std::string> view_names = view.get_index_names();
     std::sort(view_names.begin(), view_names.end());
     EXPECT_EQ(view_names, (std::vector<std::string>{"chr1", "chr2"}));
 

--- a/tests/structure/grove_view_test.cpp
+++ b/tests/structure/grove_view_test.cpp
@@ -90,6 +90,15 @@ TEST(GroveViewTest, MatchesEagerIntersectAcrossIndices) {
     EXPECT_EQ(data_values(eager.intersect(gdt::interval{0, 60})),
               data_values(view.intersect(gdt::interval{0, 60})));
 
+    // Read-side introspection parity with the eager grove.
+    EXPECT_EQ(view.get_order(), eager.get_order());  // built with order 4
+    EXPECT_EQ(view.get_order(), 4);
+
+    // index_names() enumerates the same indices the eager grove holds, order-independent.
+    std::vector<std::string> view_names = view.index_names();
+    std::sort(view_names.begin(), view_names.end());
+    EXPECT_EQ(view_names, (std::vector<std::string>{"chr1", "chr2"}));
+
     fs::remove(path);
 }
 


### PR DESCRIPTION
## Summary

### Added

A feature scan of the in-memory `grove` against the partial reader `grove_view` (issue #509) found the query and graph-read paths already at parity, but two **read-side introspection** accessors on `grove` had no view equivalent — despite the view already storing the underlying data. This adds both:

- **`int get_order() const`** — mirrors `grove::get_order()`. The view already reads and stores `order` at `open()`; this just exposes it.
- **`std::vector<std::string> get_index_names() const`** — the view-appropriate analogue of `grove::get_root_nodes()` (which returns node pointers, meaningless for a lazy view). Enumerates the index names from the in-memory directory. Without it, the all-index `intersect(query)` overload was opaque — no way to discover which indices are queryable. Returned in unspecified order, matching grove's unordered root map.

Both back onto data already held in memory from `open()` — no format change, no extra block loads, read path only.

### Out of scope (deliberately not added)

- **Mutation** (`insert*`, `add_edge`, `remove_*`, `compact`, `serialize`) — `grove_view` is read-only by design.
- **Aggregate graph/key counts** (`edge_count`, `vertex_count`, …) — the view only knows blocks paged in so far; a true total requires reading the whole file, contradicting laziness.
- **`grove_to_sif`** — a full SIF export pages in every block.

## Test plan

- [x] I, as a human being, have checked each line of code
- [x] CI green across all platforms
- [x] Extended `GroveViewTest.MatchesEagerIntersectAcrossIndices` (order-4 chr1/chr2 fixture): asserts `view.get_order() == eager.get_order() == 4` and `get_index_names()` (sorted) `== {chr1, chr2}`.

## Downstream

Matching `pygenogrove` `GroveView` bindings can surface `get_order()` / `get_index_names()`; docs follow-up after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only access to the configured B+ tree order for opened grove views.
  * Added the ability to list available index names from a grove view.
* **Tests**
  * Added coverage verifying reported tree order and index-name enumeration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


