### PR TITLE
Bound block lengths without a per-block seek (fixes #513)

### DIFF
--- a/include/genogrove/structure/grove/grove_serialize.ipp
+++ b/include/genogrove/structure/grove/grove_serialize.ipp
@@ -376,6 +376,12 @@ public:
         detail::block_inflater inflater;
         std::string comp_buf;
         std::string raw_buf;
+        // Bytes remaining in the block region, measured once. Each block's
+        // file-controlled clen is validated against this by plain subtraction
+        // instead of a per-block seek-to-end — seeking every block dominated
+        // deserialize (#513). -1 means the source is not seekable, so the
+        // per-block clen bound is skipped (the truncated-read check still fires).
+        std::streamoff block_bytes_left = detail::remaining_bytes(is);
         try {
             // ---- read every block (length-prefixed, independently compressed) ----
             for (detail::block_id b = 0; b < num_blocks; ++b) {
@@ -390,10 +396,16 @@ public:
                 if (clen > static_cast<uint64_t>(std::numeric_limits<std::streamsize>::max())) {
                     throw std::runtime_error("Failed to deserialize grove: block length out of range");
                 }
-                // clen bytes must actually remain in the stream: reject a bogus
-                // multi-GB length before resize allocates it (OOM guard) rather
-                // than after the truncated read.
-                detail::require_backing_bytes(is, clen, 1, "compressed block");
+                // clen bytes must actually remain: reject a bogus multi-GB length
+                // before resize allocates it (OOM guard). Arithmetic only — the
+                // budget was measured once above.
+                if (block_bytes_left >= 0) {
+                    block_bytes_left -= static_cast<std::streamoff>(sizeof(clen));
+                    if (block_bytes_left < 0 || clen > static_cast<uint64_t>(block_bytes_left)) {
+                        throw std::runtime_error("Failed to deserialize grove: compressed block length exceeds remaining stream");
+                    }
+                    block_bytes_left -= static_cast<std::streamoff>(clen);
+                }
                 comp_buf.resize(static_cast<size_t>(clen));
                 is.read(comp_buf.data(), static_cast<std::streamsize>(clen));
                 if (is.gcount() != static_cast<std::streamsize>(clen)) {

--- a/include/genogrove/structure/grove/grove_view.hpp
+++ b/include/genogrove/structure/grove/grove_view.hpp
@@ -287,6 +287,7 @@ class grove_view {
     detail::block_id num_blocks = 0;
     detail::block_id ext_block_begin = 0;
     std::vector<std::uint64_t> block_offsets;  // block_id -> offset of [clen][bytes]
+    std::uint64_t stream_size = 0;  // file end; bounds each block's clen without a seek (#513)
     std::unordered_map<std::string, detail::block_id> index_roots;
 
     std::deque<key_t> key_storage;  // stable addresses for loaded keys
@@ -389,6 +390,10 @@ class grove_view {
                 throw std::runtime_error("grove_view: truncated block during scan");
             }
         }
+        // End of the block region — used to bound each block's clen at load time
+        // by arithmetic instead of a per-load seek-to-end (#513).
+        const std::streampos end = is.tellg();
+        stream_size = (end == std::streampos(-1)) ? 0 : static_cast<std::uint64_t>(end);
     }
 
     // Seek to block b, read its length prefix, and inflate it into raw_buf.
@@ -413,7 +418,11 @@ class grove_view {
         if (clen > static_cast<std::uint64_t>(std::numeric_limits<std::streamsize>::max())) {
             throw std::runtime_error("grove_view: block length out of range");
         }
-        detail::require_backing_bytes(is, clen, 1, "compressed block");
+        // clen bytes must fit between this block's data start and the file end
+        // (measured once at scan time) — arithmetic only, no per-load seek (#513).
+        if (stream_size != 0 && clen > stream_size - block_offsets[b] - sizeof(clen)) {
+            throw std::runtime_error("grove_view: compressed block length exceeds file");
+        }
         comp_buf.resize(static_cast<std::size_t>(clen));
         is.read(comp_buf.data(), static_cast<std::streamsize>(clen));
         if (is.gcount() != static_cast<std::streamsize>(clen)) {

--- a/include/genogrove/structure/grove/pod_io.hpp
+++ b/include/genogrove/structure/grove/pod_io.hpp
@@ -15,6 +15,26 @@
 
 namespace genogrove::structure::detail {
 
+/// Bytes from the current get position to the end of the stream, or -1 if the
+/// source is not seekable. The position is preserved. Measuring this once and
+/// tracking it by hand avoids a seek per element in hot loops (see #513).
+inline std::streamoff remaining_bytes(std::istream& is) {
+    const std::streampos cur = is.tellg();
+    if (cur == std::streampos(-1)) {
+        return -1;  // not seekable
+    }
+    is.seekg(0, std::ios::end);
+    const std::streampos end = is.tellg();
+    is.seekg(cur, std::ios::beg);
+    // streampos only guarantees ==/!=; use the streamoff difference for ordering.
+    const std::streamoff diff = end - cur;
+    if (!is || end == std::streampos(-1) || diff < 0) {
+        is.clear();  // clear any failbit from the probe; leave unbounded
+        return -1;
+    }
+    return diff;
+}
+
 /// Reject a file-controlled element count that the remaining stream cannot
 /// possibly back. Every element occupies at least `min_bytes_per_elem` bytes on
 /// disk, so a `count` exceeding `remaining / min_bytes_per_elem` is corrupt and
@@ -25,24 +45,17 @@ namespace genogrove::structure::detail {
 ///
 /// Seekable streams only (files, stringstreams, and the seekable memory_streambuf
 /// over decompressed blocks). A non-seekable source is left unbounded — best
-/// effort rather than a false rejection. The stream position is preserved.
+/// effort rather than a false rejection. The stream position is preserved. This
+/// seeks internally, so do NOT call it per element in a hot loop — measure
+/// remaining_bytes() once and track it instead (see grove::deserialize, #513).
 inline void require_backing_bytes(std::istream& is, std::uint64_t count,
                                   std::uint64_t min_bytes_per_elem, const char* what) {
     if (count == 0 || min_bytes_per_elem == 0) {
         return;
     }
-    const std::streampos cur = is.tellg();
-    if (cur == std::streampos(-1)) {
-        return;  // not seekable — cannot bound
-    }
-    is.seekg(0, std::ios::end);
-    const std::streampos end = is.tellg();
-    is.seekg(cur, std::ios::beg);
-    // streampos only guarantees ==/!=; use the streamoff difference for ordering.
-    const std::streamoff remaining_off = end - cur;
-    if (!is || end == std::streampos(-1) || remaining_off < 0) {
-        is.clear();  // clear any failbit from the probe; leave unbounded
-        return;
+    const std::streamoff remaining_off = remaining_bytes(is);
+    if (remaining_off < 0) {
+        return;  // not seekable / undeterminable — leave unbounded
     }
     const std::uint64_t remaining = static_cast<std::uint64_t>(remaining_off);
     if (count > remaining / min_bytes_per_elem) {


### PR DESCRIPTION
## Summary

### Fixed

`github-action-benchmark` flagged `BM_read_eager` as 2–7× slower after #511 (deserialization DoS bounds). Root cause: `detail::require_backing_bytes` measures the remaining stream bytes by seeking to the end and back, and #511 placed it in the **per-block loop** of `grove::deserialize` (and in `grove_view::read_block_raw`) to bound each block's compressed length `clen`. Reading from an `ifstream`, that is two `lseek`s plus buffer-state disruption per block — and block count scales with dataset size (worst at low order = many small blocks), giving the ~7× hit at order 3 and ~2× at order 32.

The fix keeps the exact same DoS bound but removes the per-block seek:

- **Eager** (`grove::deserialize`): measure the block-region byte budget **once** before the loop (`detail::remaining_bytes`, factored out of `require_backing_bytes`) and track it by subtraction — reject `clen > bytes_left` with arithmetic only.
- **View** (`grove_view`): store the file size once at scan time (`stream_size`) and bound `clen` against `stream_size - block_offsets[b] - sizeof(clen)` — no per-load seek.

The O(1) directory checks (index count, index name lengths, block count) still use the seek-based `require_backing_bytes` — they run a handful of times and aren't hot.

## Verification

- The DoS regression suite still fires: a huge `clen`, huge external-key count, etc. all throw `runtime_error` (the `HugeCompressedBlockLengthRejected` path now rejects via the arithmetic budget). A 1500-key grove round-trips.
- Local timing of the worst-regressed case (10000 keys, order 3, file deserialize, -O2): **~4.4 ms/iter**, back in the pre-#511 baseline band (~5.4 ms reported), versus the regressed ~38 ms.

No behavior change to the bound (same values rejected), no public API or `.gg` format change.

## Test plan

- [x] I, as a human being, have checked each line of code
- [x] CI green across all platforms
- [x] Existing `SerializationDoSTest` (huge block/index/name/string counts, external-key cap, inflater cap) still asserts `runtime_error`; roundtrip suites confirm valid streams are unaffected. Perf itself is validated by the benchmark job on merge.
