### PR TITLE
Release v0.25.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.25.5] - 2026-07-22
+## [0.25.5] - 2026-07-23
 
 ### Added
 - **`grove_view` read-side introspection: `get_order()` and `get_index_names()`**: the partial (random-access) reader gains two accessors that were present on the in-memory `grove` but had no view equivalent, despite the view already holding the data from `open()`. `get_order()` returns the B+ tree order (mirrors `grove::get_order()`); `get_index_names()` returns `std::vector<std::string>` of every index (e.g. chromosome) in the `.gg`, in unspecified order — the view-appropriate analogue of `grove::get_root_nodes()` (which returns node pointers meaningless to a lazy view), letting a caller discover what `intersect(query)` / `flanking` can run against. Both read nothing extra (no block loads, no format change). Mutation, aggregate graph/key counts, and `grove_to_sif` were deliberately left out — the first is write-only, the latter two would force reading the whole file, contradicting the lazy design. ([#509](https://github.com/genogrove/genogrove/issues/509), [#510](https://github.com/genogrove/genogrove/pull/510))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.5] - 2026-07-22
+
 ### Added
 - **`grove_view` read-side introspection: `get_order()` and `get_index_names()`**: the partial (random-access) reader gains two accessors that were present on the in-memory `grove` but had no view equivalent, despite the view already holding the data from `open()`. `get_order()` returns the B+ tree order (mirrors `grove::get_order()`); `get_index_names()` returns `std::vector<std::string>` of every index (e.g. chromosome) in the `.gg`, in unspecified order — the view-appropriate analogue of `grove::get_root_nodes()` (which returns node pointers meaningless to a lazy view), letting a caller discover what `intersect(query)` / `flanking` can run against. Both read nothing extra (no block loads, no format change). Mutation, aggregate graph/key counts, and `grove_to_sif` were deliberately left out — the first is write-only, the latter two would force reading the whole file, contradicting the lazy design. ([#509](https://github.com/genogrove/genogrove/issues/509), [#510](https://github.com/genogrove/genogrove/pull/510))
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(genogrove VERSION 0.25.4)
+project(genogrove VERSION 0.25.5)
 
 find_package(PkgConfig REQUIRED)
 find_package(ZLIB REQUIRED)


### PR DESCRIPTION
## Summary

Patch release **v0.25.5** — additive + fixes + docs. No `.gg` format change, no breaking API change; existing indexes remain compatible.

### Contents (from `[Unreleased]`)

- **Added** — `grove_view::get_order()` and `get_index_names()`: read-side introspection parity with the in-memory grove ([#509](https://github.com/genogrove/genogrove/issues/509), [#510](https://github.com/genogrove/genogrove/pull/510)).
- **Changed** — `registry` lock-free read contract restated: the unlocked `get`/`contains`/`size`/`empty` are documented as UB under concurrent writers (docs only) ([#487](https://github.com/genogrove/genogrove/issues/487), [#515](https://github.com/genogrove/genogrove/pull/515)).
- **Fixed** — `distribute_evenly` computed in `size_t`, fixing silent corruption of bulk builds above `INT_MAX` keys ([#486](https://github.com/genogrove/genogrove/issues/486), [#512](https://github.com/genogrove/genogrove/pull/512)); and file-controlled allocation counts are bounded when reading a serialized `.gg`, closing an untrusted-input DoS ([#484](https://github.com/genogrove/genogrove/issues/484), [#511](https://github.com/genogrove/genogrove/pull/511)).

The #511 deserialization-bounds fix and its follow-up perf fix ([#513](https://github.com/genogrove/genogrove/issues/513) / [#514](https://github.com/genogrove/genogrove/pull/514)) both land here — the per-block seek regression #514 corrected never shipped, so it has no separate CHANGELOG line.

## Release mechanics

- Bumped `project(genogrove VERSION 0.25.5)` in `CMakeLists.txt`.
- Promoted `## [Unreleased]` → `## [0.25.5] - 2026-07-23` in `CHANGELOG.md` (empty `[Unreleased]` retained above).

## Test plan

- [ ] I, as a human being, have checked each line of code
- [x] CI green across all platforms
- [x] `CHANGELOG.md` — `[Unreleased]` empty, `[0.25.5]` dated with all entries
- [x] `CMakeLists.txt` — version is `0.25.5`

## Follow-ups (after merge)

- [x] Tag the merge commit: `git tag -a v0.25.5 -m "Release v0.25.5"` && push
- [x] Create the GitHub release for `v0.25.5`
- [x] File the docs version-bump issue in `genogrove/docs` (`conf.py` version + README badge)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the package version to **0.25.5**.
  * Added the **0.25.5** changelog entry dated **July 23, 2026**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


