### PR TITLE
Benchmark pull requests against their base on one runner

### DIFF
--- a/.github/workflows/pr-benchmark.yml
+++ b/.github/workflows/pr-benchmark.yml
@@ -39,29 +39,33 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     steps:
-      # Default checkout for a pull_request event is the PR merged into the base
-      # branch, which is what we want to measure: base vs "base with this PR".
-      # Anything that landed on the base since the branch forked is then present
-      # on both sides and cancels out.
+      # Default checkout for a pull_request event is the PR merged into the base,
+      # which is what we want as "head": base plus this PR.
+      #
+      # persist-credentials is off on both checkouts because this job executes
+      # PR-controlled code — the PR's own CMakeLists during configure, then its
+      # compiled benchmark binary — and neither needs a token in git config.
       - name: Checkout PR merge result
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          persist-credentials: false
+
+      # The base side must be the exact commit the merge result was computed
+      # against, not the branch tip at job start. If anything lands on the base
+      # in between, the two sides straddle different base commits and unrelated
+      # changes get attributed to this PR — the very error this job exists to
+      # rule out. workflow_dispatch has no event payload, so it falls back to main.
+      - name: Checkout the base commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha || 'main' }}
+          path: base
+          persist-credentials: false
 
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake ninja-build g++ libhts-dev
-
-      - name: Add a worktree at the base branch
-        env:
-          BASE_REF: ${{ github.base_ref || 'main' }}
-        run: |
-          # checkout only guarantees the ref it checked out, so fetch the base
-          # explicitly rather than assuming origin/<base> exists.
-          git fetch --no-tags origin "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
-          git worktree add ../base "origin/$BASE_REF"
-          git -C ../base log -1 --format='base is %h %s'
 
       # FETCHCONTENT_BASE_DIR is shared so google-benchmark is downloaded once
       # rather than per build tree. Only the benchmark target is built.
@@ -69,7 +73,7 @@ jobs:
         run: |
           for side in head base; do
             src="."
-            [ "$side" = base ] && src="../base"
+            [ "$side" = base ] && src="base"
             cmake -B "build-$side" -S "$src" \
               -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
@@ -93,7 +97,8 @@ jobs:
           FILTER: 'BM_control_|/(1000|5000)/(3|15|100)$'
         run: |
           for round in 1 2 3; do
-            for side in head base; do
+            if [ $((round % 2)) -eq 1 ]; then order="head base"; else order="base head"; fi
+            for side in $order; do
               ( cd "build-$side/benchmarks" && ./genogrove_benchmarks \
                   --benchmark_filter="$FILTER" \
                   --benchmark_min_time=0.25s \
@@ -103,11 +108,26 @@ jobs:
           done
 
       - name: Compare
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || 'main' }}
         run: |
+          # Each side builds its own benchmark sources, so if this PR edits a
+          # benchmark's workload then identically named benchmarks measure
+          # different work on the two sides and the ratios mean nothing. Say so
+          # rather than presenting the table as fact. Data files are excluded:
+          # both sides read this checkout's copies by construction.
+          warn=()
+          if ! diff -qr -x data benchmarks base/benchmarks > /dev/null 2>&1; then
+            warn+=(--warn "The benchmark sources differ between the two sides, so identically named benchmarks may not measure the same work. Read the ratios below as indicative only.")
+          fi
           python3 benchmarks/compare_ab.py \
             --head build-head/benchmarks/result-head-*.json \
             --base build-base/benchmarks/result-base-*.json \
             --threshold 1.20 \
+            --head-sha "$HEAD_SHA" \
+            --base-sha "$BASE_SHA" \
+            "${warn[@]}" \
             --out report.md
 
       - name: Publish to the job summary

--- a/.github/workflows/pr-benchmark.yml
+++ b/.github/workflows/pr-benchmark.yml
@@ -1,0 +1,142 @@
+name: PR Benchmark A/B
+
+# Builds this PR and the branch it targets on ONE runner and runs them
+# alternately, so host speed cancels out.
+#
+# The continuous-benchmarking job on main cannot do this: it compares a commit
+# against its predecessor, measured on whichever shared runner each got, and
+# those hosts routinely differ by 30% or more. That is how #518 shipped a 1.5x
+# insert regression that the dashboard reported as 2.05x mixed in with a 2.00x
+# move in untouched code — see the analysis on that PR. Comparing on one host
+# removes the guesswork.
+#
+# Only runs when something that could plausibly change performance is touched;
+# doc- and test-only PRs skip it.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'include/**'
+      - 'src/**'
+      - 'benchmarks/**'
+      - 'CMakeLists.txt'
+      - '.github/workflows/pr-benchmark.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# A new push supersedes an in-flight comparison for the same PR.
+concurrency:
+  group: pr-benchmark-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compare:
+    name: A/B against the base branch
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-24.04
+    steps:
+      # Default checkout for a pull_request event is the PR merged into the base
+      # branch, which is what we want to measure: base vs "base with this PR".
+      # Anything that landed on the base since the branch forked is then present
+      # on both sides and cancels out.
+      - name: Checkout PR merge result
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build g++ libhts-dev
+
+      - name: Add a worktree at the base branch
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+        run: |
+          # checkout only guarantees the ref it checked out, so fetch the base
+          # explicitly rather than assuming origin/<base> exists.
+          git fetch --no-tags origin "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
+          git worktree add ../base "origin/$BASE_REF"
+          git -C ../base log -1 --format='base is %h %s'
+
+      # FETCHCONTENT_BASE_DIR is shared so google-benchmark is downloaded once
+      # rather than per build tree. Only the benchmark target is built.
+      - name: Build both sides
+        run: |
+          for side in head base; do
+            src="."
+            [ "$side" = base ] && src="../base"
+            cmake -B "build-$side" -S "$src" \
+              -G Ninja \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DBUILD_BENCHMARKS=ON \
+              -DCMAKE_CXX_COMPILER=g++ \
+              -DFETCHCONTENT_BASE_DIR="$PWD/.deps"
+            cmake --build "build-$side" --target genogrove_benchmarks
+            # Deliberately this checkout's data for both sides: comparing two
+            # builds only means something if they read identical input.
+            mkdir -p "build-$side/benchmarks/data"
+            cp benchmarks/data/*_intervals_*.txt "build-$side/benchmarks/data/"
+          done
+
+      # Three rounds, alternating within each round so slow drift over the job
+      # affects both sides equally. One repetition per invocation — the rounds
+      # are the repetitions, and compare_ab.py takes the fastest per side.
+      - name: Run interleaved rounds
+        env:
+          # Every family at two sizes and three orders, plus the controls, which
+          # verify the two sides really did see the same machine.
+          FILTER: 'BM_control_|/(1000|5000)/(3|15|100)$'
+        run: |
+          for round in 1 2 3; do
+            for side in head base; do
+              ( cd "build-$side/benchmarks" && ./genogrove_benchmarks \
+                  --benchmark_filter="$FILTER" \
+                  --benchmark_min_time=0.25s \
+                  --benchmark_out="result-$side-$round.json" \
+                  --benchmark_out_format=json > /dev/null )
+            done
+          done
+
+      - name: Compare
+        run: |
+          python3 benchmarks/compare_ab.py \
+            --head build-head/benchmarks/result-head-*.json \
+            --base build-base/benchmarks/result-base-*.json \
+            --threshold 1.20 \
+            --out report.md
+
+      - name: Publish to the job summary
+        if: always()
+        run: |
+          if [ -f report.md ]; then
+            cat report.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "The benchmark comparison did not produce a report — see the step logs." \
+              >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      # Fork PRs get a read-only token, so this cannot post there. That is why
+      # the job summary above is the primary output and this step never fails
+      # the job.
+      - name: Update the sticky PR comment
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          marker='<!-- pr-benchmark-ab -->'
+          { echo "$marker"; cat report.md; } > comment.md
+          existing=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+            --jq "[.[] | select(.body | startswith(\"$marker\"))] | first | .id // empty")
+          if [ -n "$existing" ]; then
+            gh api "repos/$REPO/issues/comments/$existing" -X PATCH -F body=@comment.md
+          else
+            gh pr comment "$PR" --repo "$REPO" --body-file comment.md
+          fi

--- a/.github/workflows/pr-benchmark.yml
+++ b/.github/workflows/pr-benchmark.yml
@@ -109,9 +109,17 @@ jobs:
 
       - name: Compare
         env:
+          # The PR's own head commit, not the ephemeral refs/pull/N/merge SHA
+          # that is actually built: the merge SHA appears nowhere in the PR UI,
+          # so it tells a reviewer nothing. github.sha covers workflow_dispatch.
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha || 'main' }}
         run: |
+          # Read the base commit back out of the checkout rather than trusting
+          # the event payload, so the report states what was genuinely built.
+          # This also gives workflow_dispatch a real SHA instead of the branch
+          # name the checkout step falls back to.
+          BASE_SHA=$(git -C base rev-parse HEAD)
+
           # Each side builds its own benchmark sources, so if this PR edits a
           # benchmark's workload then identically named benchmarks measure
           # different work on the two sides and the ratios mean nothing. Say so

--- a/.github/workflows/pr-benchmark.yml
+++ b/.github/workflows/pr-benchmark.yml
@@ -115,10 +115,14 @@ jobs:
           # Each side builds its own benchmark sources, so if this PR edits a
           # benchmark's workload then identically named benchmarks measure
           # different work on the two sides and the ratios mean nothing. Say so
-          # rather than presenting the table as fact. Data files are excluded:
-          # both sides read this checkout's copies by construction.
+          # rather than presenting the table as fact.
+          #
+          # Only what compiles into the binary counts. Data files are excluded
+          # because both sides read this checkout's copies by construction, and
+          # the Python helpers because they post-process results rather than
+          # affect them — warning about those would be crying wolf.
           warn=()
-          if ! diff -qr -x data benchmarks base/benchmarks > /dev/null 2>&1; then
+          if ! diff -qr -x data -x '*.py' benchmarks base/benchmarks > /dev/null 2>&1; then
             warn+=(--warn "The benchmark sources differ between the two sides, so identically named benchmarks may not measure the same work. Read the ratios below as indicative only.")
           fi
           python3 benchmarks/compare_ab.py \

--- a/benchmarks/compare_ab.py
+++ b/benchmarks/compare_ab.py
@@ -48,7 +48,7 @@ def fastest_per_benchmark(paths):
     return best
 
 
-def format_report(head, base, threshold):
+def format_report(head, base, threshold, head_sha=None, base_sha=None, warnings=()):
     shared = [n for n in head if n in base and base[n] > 0]
     controls = sorted(n for n in shared if n.startswith(CONTROL_PREFIX))
     measured = [n for n in shared if not n.startswith(CONTROL_PREFIX)]
@@ -58,6 +58,16 @@ def format_report(head, base, threshold):
     improvements = [(r, n) for r, n in ratios if r <= 1 / threshold]
 
     lines = ["## Benchmark A/B (same runner, interleaved)", ""]
+
+    # State which commits produced these numbers. The report is normally posted
+    # as a comment that is edited in place, so without this a reader cannot tell
+    # whether it describes the current tip or a superseded push.
+    if head_sha or base_sha:
+        lines.append(f"`{(head_sha or '?')[:12]}` (this PR) vs `{(base_sha or '?')[:12]}` (base)")
+        lines.append("")
+
+    for warning in warnings:
+        lines += [f"> ⚠️ {warning}", ""]
 
     if controls:
         lines += ["<details><summary>Machine controls — these should read ~1.00x</summary>", ""]
@@ -120,6 +130,10 @@ def main(argv=None):
     parser.add_argument("--fail-over", type=float, default=None,
                         help="exit non-zero if any benchmark is slower than this ratio")
     parser.add_argument("--out", default=None, help="write the markdown report here as well as stdout")
+    parser.add_argument("--head-sha", default=None, help="commit measured as head, shown in the report")
+    parser.add_argument("--base-sha", default=None, help="commit measured as base, shown in the report")
+    parser.add_argument("--warn", action="append", default=None,
+                        help="caveat to print above the table; repeatable")
     args = parser.parse_args(argv)
 
     head = fastest_per_benchmark(args.head)
@@ -128,7 +142,8 @@ def main(argv=None):
         print("error: one side produced no benchmark rows", file=sys.stderr)
         return 2
 
-    report, worst = format_report(head, base, args.threshold)
+    report, worst = format_report(head, base, args.threshold,
+                                  args.head_sha, args.base_sha, args.warn or ())
     print(report)
     if args.out:
         with open(args.out, "w") as handle:

--- a/benchmarks/compare_ab.py
+++ b/benchmarks/compare_ab.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Compare two sets of google-benchmark runs measured on the same machine.
+
+The continuous-benchmarking dashboard compares a commit against its predecessor,
+which were measured on *different* shared runners — differences of 30% or more
+between hosts are routine, so a ratio there mixes "the code changed" with "the
+machine changed" and cannot be acted on. This script instead compares two builds
+run alternately on one host, so the host cancels out.
+
+Both sides may be given several files (one per interleaved round). The fastest
+sample per benchmark per side is used: a slow sample means something else on the
+runner interfered, which is noise rather than a slower library.
+
+The control benchmarks (BM_control_*) are reported separately. They do fixed work
+in no genogrove code, so if they differ between the two sides the measurement
+itself is suspect — something disturbed the run and the rest of the table should
+be read with suspicion.
+
+Usage:
+  compare_ab.py --head h1.json [h2.json ...] --base b1.json [b2.json ...]
+                [--threshold 1.20] [--out report.md]
+
+Exit status is 0 unless --fail-over is given and exceeded.
+"""
+
+import argparse
+import json
+import sys
+
+CONTROL_PREFIX = "BM_control"
+
+
+def fastest_per_benchmark(paths):
+    """Minimum real_time per benchmark name across all given report files."""
+    best = {}
+    for path in paths:
+        with open(path) as handle:
+            report = json.load(handle)
+        for entry in report.get("benchmarks", []):
+            if entry.get("run_type") == "aggregate" or entry.get("error_occurred"):
+                continue
+            name = entry.get("run_name") or entry.get("name")
+            time = entry.get("real_time")
+            if name is None or time is None:
+                continue
+            if name not in best or time < best[name]:
+                best[name] = time
+    return best
+
+
+def format_report(head, base, threshold):
+    shared = [n for n in head if n in base and base[n] > 0]
+    controls = sorted(n for n in shared if n.startswith(CONTROL_PREFIX))
+    measured = [n for n in shared if not n.startswith(CONTROL_PREFIX)]
+
+    ratios = sorted(((head[n] / base[n], n) for n in measured), reverse=True)
+    regressions = [(r, n) for r, n in ratios if r >= threshold]
+    improvements = [(r, n) for r, n in ratios if r <= 1 / threshold]
+
+    lines = ["## Benchmark A/B (same runner, interleaved)", ""]
+
+    if controls:
+        lines += ["<details><summary>Machine controls — these should read ~1.00x</summary>", ""]
+        lines += ["| control | base | head | ratio |", "|---|---|---|---|"]
+        for name in controls:
+            lines.append(
+                f"| `{name}` | {base[name]:.1f} | {head[name]:.1f} | {head[name] / base[name]:.2f}x |"
+            )
+        drift = max(abs(head[n] / base[n] - 1.0) for n in controls)
+        lines += [""]
+        if drift > 0.05:
+            lines.append(
+                f"⚠️ Controls differ by {drift * 100:.0f}%. Both sides ran on one host, so this "
+                "means the run was disturbed — treat the table below as unreliable."
+            )
+        else:
+            lines.append("Controls agree, so the comparison below reflects code rather than host.")
+        lines += ["", "</details>", ""]
+    else:
+        lines += ["> No control benchmarks in the filter — host stability was not verified.", ""]
+
+    if not measured:
+        lines.append("No benchmarks in common between the two sides.")
+        return "\n".join(lines), 0.0
+
+    worst = ratios[0][0]
+    lines.append(
+        f"{len(measured)} benchmarks compared. "
+        f"Slowest {worst:.2f}x, fastest {ratios[-1][0]:.2f}x, "
+        f"median {sorted(r for r, _ in ratios)[len(ratios) // 2]:.2f}x."
+    )
+    lines.append("")
+
+    if regressions:
+        lines += [f"### Slower by {threshold:.2f}x or more", "", "| benchmark | base | head | ratio |", "|---|---|---|---|"]
+        for r, n in regressions[:25]:
+            lines.append(f"| `{n}` | {base[n]:.1f} | {head[n]:.1f} | **{r:.2f}x** |")
+        if len(regressions) > 25:
+            lines.append(f"| … {len(regressions) - 25} more | | | |")
+        lines.append("")
+    else:
+        lines += [f"No benchmark is slower by {threshold:.2f}x or more.", ""]
+
+    if improvements:
+        lines += [f"### Faster by {threshold:.2f}x or more", "", "| benchmark | base | head | ratio |", "|---|---|---|---|"]
+        for r, n in improvements[-25:]:
+            lines.append(f"| `{n}` | {base[n]:.1f} | {head[n]:.1f} | **{r:.2f}x** |")
+        lines.append("")
+
+    lines.append("All times are the fastest sample per benchmark, in the unit google-benchmark reported.")
+    return "\n".join(lines), worst
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--head", nargs="+", required=True, help="report files for the PR build")
+    parser.add_argument("--base", nargs="+", required=True, help="report files for the base build")
+    parser.add_argument("--threshold", type=float, default=1.20,
+                        help="ratio at which a benchmark is listed as slower (default 1.20)")
+    parser.add_argument("--fail-over", type=float, default=None,
+                        help="exit non-zero if any benchmark is slower than this ratio")
+    parser.add_argument("--out", default=None, help="write the markdown report here as well as stdout")
+    args = parser.parse_args(argv)
+
+    head = fastest_per_benchmark(args.head)
+    base = fastest_per_benchmark(args.base)
+    if not head or not base:
+        print("error: one side produced no benchmark rows", file=sys.stderr)
+        return 2
+
+    report, worst = format_report(head, base, args.threshold)
+    print(report)
+    if args.out:
+        with open(args.out, "w") as handle:
+            handle.write(report + "\n")
+
+    if args.fail_over is not None and worst >= args.fail_over:
+        print(f"\nerror: slowest benchmark {worst:.2f}x exceeds --fail-over {args.fail_over:.2f}x",
+              file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Follow-up to the #518 post-mortem. Benchmarks currently run only on `push` to `main`, so a performance regression is discovered *after* merge — and the dashboard's comparison is between two different shared runners, which is why #518's real 1.5× insert regression arrived reported as 2.05× next to a 2.00× move in code it never touched.

This adds a PR job that does the comparison properly: build both sides on **one runner** and interleave them, so the host cancels out.

### How it works

1. Build the PR merged into its base (`refs/pull/N/merge`) and the base tip — two build trees, one runner, sharing one `FETCHCONTENT_BASE_DIR` so google-benchmark is downloaded once.
2. Three rounds, alternating head/base within each round, so drift over the job affects both sides equally.
3. `compare_ab.py` takes the fastest sample per benchmark per side and reports ratios.

Comparing against the base *tip* rather than the fork point is deliberate: anything that landed on the base since branching is then present on both sides and cancels, leaving only this PR's contribution.

### The controls are the self-check

The filter includes `BM_control_cpu` / `BM_control_memory` (added in `0d1bc7b`). They do fixed work in no genogrove code, so across two builds on one host they must read ~1.00×. If they don't, the run was disturbed and the report says so rather than presenting the table as fact — a sanity check the cross-run dashboard structurally cannot have.

### Cost and scope

- Filter keeps **42 of 310** benchmarks (every family at 2 sizes × 3 orders, plus controls) ≈ 1 minute of measurement; the two builds dominate the job.
- Triggers only on `include/**`, `src/**`, `benchmarks/**`, `CMakeLists.txt` and this workflow — doc- and test-only PRs skip it entirely.
- Skips draft PRs; a new push cancels the in-flight run for the same PR.
- **Non-blocking**: reports, never fails. Turning it into a gate is a one-line `--fail-over` once the same-host noise floor is known from real runs (paired with #524, the threshold question for the main dashboard).

### Reporting

Job summary first, sticky PR comment second. Fork PRs get a read-only token and cannot comment, so the summary is the primary output and the comment step is `continue-on-error`.

## Validation

Full CI validation is only possible by running it, which is why this PR self-tests: its own paths are in the trigger filter, so the job runs here. Since the diff is CI files only, the expected result is no significant differences with controls at ~1.00×.

Verified before pushing:

- workflow YAML parses; step order checked
- the benchmark filter regex selects 42 of the 310 names actually on the dashboard
- `compare_ab.py` exercised on synthetic reports: correctly surfaces a planted 1.55× regression, reports control drift, and handles the no-common-benchmarks case
- the run/compare shell logic dry-run locally against a real google-benchmark binary: filter accepted, six round files produced, glob expansion and comparison correct, and running the *same* binary on both sides reported controls at exactly 1.00×

## Test plan

- [x] I, as a human being, have checked each line of code
- [x] The job runs on this PR and posts a report (self-test) — succeeded in 3m25s, all 9 steps green
- [x] Controls read ~1.00×, confirming both sides saw the same host — 1.00× and 0.98×
- [x] Report shows no significant differences, as expected for a CI-only diff — 40 benchmarks, median 1.00×, worst 1.02×
- [x] Existing CI jobs unaffected — all 7 build jobs pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated A/B pull request benchmarks against the base branch.
  * Generates a Markdown performance report with regressions, improvements, and benchmark consistency checks (including control drift).
  * Includes optional commit identifiers and emits repeatable caveats when benchmark sources differ.
  * Publishes results to the workflow summary and updates/creates a persistent PR comment.

* **Chores**
  * Improved benchmark execution and reporting by running multiple rounds and ensuring shared dependency fetching.
  * Kept workflow concurrency to cancel outdated runs for the same PR/ref.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
