### PR TITLE
Say why paged nodes carry no subtree max

### DIFF
--- a/include/genogrove/structure/grove/grove_view.hpp
+++ b/include/genogrove/structure/grove/grove_view.hpp
@@ -432,6 +432,19 @@ class grove_view {
     }
 
     // Load (or return cached) a node block and record its child/next references.
+    //
+    // Nodes built here have no cached subtree max. That cache is derived state:
+    // the in-memory tree maintains it through the insert and remove paths, and
+    // grove::deserialize rebuilds it after linking children — neither of which
+    // runs for a paged view. Leaving it null is deliberate rather than an
+    // oversight, because nothing here routes by maximum; search_overlaps and
+    // search_flanking prune on the separator bounding boxes, which do come out
+    // of the block.
+    //
+    // Anything added here that does want to route by maximum (see
+    // node::get_subtree_max) has to populate it first. A null max reads as "no
+    // bound", so the descent would enter that child unconditionally — silently
+    // wrong rather than an error.
     node_t* load_node(detail::block_id b) {
         if (b >= ext_block_begin) {
             throw std::runtime_error("grove_view: node block id out of range");


### PR DESCRIPTION
## Summary

Fixes #520. Documentation only, no behavior change — one comment block, no code touched.

`node::get_subtree_max()` already carries the qualification the issue asked for; it was added in #522 when the cache became a pointer:

```
* @note Maintained by the in-memory tree paths and rebuilt on deserialize.
*       The paged `grove_view` leaves it null — nothing there routes.
```

What remained is the issue's second suggestion: the same note where the question actually comes up. Someone working inside `grove_view` is unlikely to open `node.hpp` to discover why the nodes they just built have no maxima, and `load_node` is the site that would prompt the question.

The comment records three things:

- the omission is **deliberate** — the cache is derived state, maintained by the insert and remove paths and rebuilt by `grove::deserialize`, neither of which runs for a paged view;
- nothing in the view needs it — `search_overlaps` and `search_flanking` prune on the separator bounding boxes, which *do* come out of the block (verified: `query_engine.hpp` contains zero references to `get_subtree_max`);
- the failure mode for anyone who later wants to route by maximum here — a null max reads as "no bound", so the descent enters that child unconditionally. Silently wrong rather than an error, which is why it is worth a comment rather than leaving it to be discovered.

### Note for closing #520

The issue body says view nodes carry `std::nullopt`. That is stale — #522 changed the cache from `std::optional<key_type>` to a borrowed `gdt::key<...>*`, so it is `nullptr` now. The reasoning is unaffected.

## Test plan

- [x] I, as a human being, have checked each line of code
- [x] CI green — comment-only change, so a green build is the whole check — 8/8 checks pass
- [x] No behavior change: nothing outside a comment block is touched — diff is 13 added lines, 0 of them non-comment; A/B reports median 1.00x


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how paged grove views handle cached subtree maximum values.
  * Documented query pruning behavior and considerations for future maximum-based routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
