### PR TITLE
Fail the A/B check past 1.25x

### DIFF
--- a/.github/workflows/pr-benchmark.yml
+++ b/.github/workflows/pr-benchmark.yml
@@ -144,10 +144,18 @@ jobs:
           if ! diff -q <(workload benchmarks) <(workload base/benchmarks) > /dev/null 2>&1; then
             warn+=(--warn "The benchmark sources differ between the two sides, so identically named benchmarks may not measure the same work. Read the ratios below as indicative only.")
           fi
+          # Two tiers. --threshold lists a benchmark as slower; --fail-over
+          # fails the check. Measured noise for this job is 1.06x worst case
+          # across 8 runs x 40 benchmarks on unchanged code, so 1.25 leaves
+          # real headroom while catching anything like the 1.53x that reached
+          # main in #518. Not tighter than that: a PR restructuring hot code
+          # can move a benchmark ~10% on layout and inlining luck alone, which
+          # should be visible without failing a build. See #524.
           python3 benchmarks/compare_ab.py \
             --head build-head/benchmarks/result-head-*.json \
             --base build-base/benchmarks/result-base-*.json \
             --threshold 1.20 \
+            --fail-over 1.25 \
             --head-sha "$HEAD_SHA" \
             --base-sha "$BASE_SHA" \
             "${warn[@]}" \
@@ -166,8 +174,11 @@ jobs:
       # Fork PRs get a read-only token, so this cannot post there. That is why
       # the job summary above is the primary output and this step never fails
       # the job.
+      # always(), not the default success(): once --fail-over can fail the
+      # Compare step, the default would skip this exactly when the gate fires
+      # and the numbers are most worth having on the PR.
       - name: Update the sticky PR comment
-        if: github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/benchmarks/compare_ab.py
+++ b/benchmarks/compare_ab.py
@@ -149,7 +149,10 @@ def main(argv=None):
         with open(args.out, "w") as handle:
             handle.write(report + "\n")
 
-    if args.fail_over is not None and worst >= args.fail_over:
+    # Strictly greater, matching both the module docstring ("exceeded") and
+    # this flag's help ("slower than this ratio"). --threshold stays inclusive,
+    # since it is documented as the ratio *at which* a benchmark is listed.
+    if args.fail_over is not None and worst > args.fail_over:
         print(f"\nerror: slowest benchmark {worst:.2f}x exceeds --fail-over {args.fail_over:.2f}x",
               file=sys.stderr)
         return 1


### PR DESCRIPTION
## Summary

Fixes #524, though not the way that issue proposed — the data reversed its premise.

**Today neither benchmark system can fail anything.** The dashboard alerts at 200% with `fail-on-alert: false`; the A/B passes `--threshold` but no `--fail-over`, so `compare_ab.py` always exits 0. That combination is how #518's 1.53x insert regression reached `main`: under the dashboard's threshold, and the A/B did not exist yet.

## The measurements

Eight A/B runs have accumulated (#525, #528, #529), all on diffs touching no library hot path, 40 benchmarks each:

| | |
|---|---|
| median, every run | 1.00-1.01x |
| **worst single benchmark, all 320 measurements** | **1.06x** |
| control drift | never past 2% |

The dashboard, measured with the same controls on identical fixed work:

| commit | `control_cpu` | `control_memory` |
|---|---|---|
| 0d1bc7b | 140.7 us | 1416.5 us |
| 61839bb | 140.7 us | 1433.1 us |
| 5920b8b | 130.5 us | **3694.0 us** |
| 775878e | 130.2 us | **3706.9 us** |

**2.62x on the memory control** — and not jitter, since two runs sit near 1420 and two near 3700, which reads as different classes of runner. The A/B is roughly 25x tighter on the same question.

## What changes

```diff
             --threshold 1.20 \
+            --fail-over 1.25 \
```

```diff
       - name: Update the sticky PR comment
-        if: github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request'
```

Two tiers: `--threshold 1.20` lists a benchmark as slower, `--fail-over 1.25` fails the check. So 1.20-1.25 is a warning band that reports without blocking.

1.25 rather than something tighter is deliberate. All eight samples come from trivial diffs, and a PR that genuinely restructures hot code can move a benchmark ~10% through code layout and inlining luck; that should be visible, not fatal. The job is not a required check, so a real performance tradeoff can still be merged over a red mark — the gate exists to make a regression impossible to *miss*, not impossible to ship.

The `always()` is load-bearing: the step defaulted to `success()`, so once Compare can fail, the comment would be skipped exactly when the gate fires and the numbers matter most.

**The dashboard threshold is left at 200%**, against this issue's original suggestion of lowering it. With fixed work varying 2.62x between runners, no threshold makes that comparison reliable; its alerts are best read as a prompt to check the controls.

## Verification

CI can only exercise the non-firing path, so the gate was verified locally against synthetic reports:

| worst benchmark | listed as slower | exit code |
|---|---|---|
| 1.18x | no | 0 |
| 1.22x | yes | 0 |
| 1.30x | yes | **1** |

## Test plan

- [x] I, as a human being, have checked each line of code
- [x] The A/B job runs on this PR and passes (self-test of the non-firing path) — slowest 1.03x, median 1.01x
- [x] The sticky comment still posts — confirmed on this PR, which also exercises the always() change
- [x] Existing CI unaffected — 7/7 build jobs pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Benchmark pull request reports now remain available even when performance exceeds the failure threshold.
  * Added a stricter benchmark failure threshold alongside the existing warning threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
